### PR TITLE
Add record-count drop guard; fix null article_url on all records

### DIFF
--- a/content/ms/win/buildnumbers.json
+++ b/content/ms/win/buildnumbers.json
@@ -13,8 +13,8 @@
       "https://support.microsoft.com/en-us/topic/windows-server-2025-update-history-10f58da7-e57b-4a9d-9c16-9f1dcd72d7d7",
       "https://support.microsoft.com/en-us/topic/release-notes-for-hotpatch-on-windows-11-enterprise-version-25h2-0bbaa1c7-5070-41ca-a7c9-4ead79602dbf"
     ],
-    "lastModified": "2026-07-22T14:27:06Z",
-    "lastCollected": "2026-07-22T14:27:06Z"
+    "lastModified": "2026-07-22T16:02:18Z",
+    "lastCollected": "2026-07-22T16:02:18Z"
   },
   "data": [
     {
@@ -27,7 +27,7 @@
       "kb_article": "KB3135173",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3135173"
     },
     {
       "full_version": "10.0.10586.122",
@@ -39,7 +39,7 @@
       "kb_article": "KB3140743",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3140743"
     },
     {
       "full_version": "10.0.10586.164",
@@ -51,7 +51,7 @@
       "kb_article": "KB3140768",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3140768"
     },
     {
       "full_version": "10.0.10586.218",
@@ -63,7 +63,7 @@
       "kb_article": "KB3147458",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3147458"
     },
     {
       "full_version": "10.0.10586.318",
@@ -75,7 +75,7 @@
       "kb_article": "KB3156421",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3156421"
     },
     {
       "full_version": "10.0.10586.420",
@@ -87,7 +87,7 @@
       "kb_article": "KB3163018",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3163018"
     },
     {
       "full_version": "10.0.10586.494",
@@ -99,7 +99,7 @@
       "kb_article": "KB3172985",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3172985"
     },
     {
       "full_version": "10.0.14393.10",
@@ -111,7 +111,7 @@
       "kb_article": "KB3176929",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176929"
     },
     {
       "full_version": "10.0.14393.10",
@@ -123,7 +123,7 @@
       "kb_article": "KB3176929",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176929"
     },
     {
       "full_version": "10.0.10586.545",
@@ -135,7 +135,7 @@
       "kb_article": "KB3176493",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176493"
     },
     {
       "full_version": "10.0.14393.51",
@@ -147,7 +147,7 @@
       "kb_article": "KB3176495",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176495"
     },
     {
       "full_version": "10.0.14393.51",
@@ -159,7 +159,7 @@
       "kb_article": "KB3176495",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176495"
     },
     {
       "full_version": "10.0.14393.82",
@@ -171,7 +171,7 @@
       "kb_article": "KB3176934",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176934"
     },
     {
       "full_version": "10.0.14393.82",
@@ -183,7 +183,7 @@
       "kb_article": "KB3176934",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176934"
     },
     {
       "full_version": "10.0.14393.105",
@@ -195,7 +195,7 @@
       "kb_article": "KB3176938",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176938"
     },
     {
       "full_version": "10.0.14393.105",
@@ -207,7 +207,7 @@
       "kb_article": "KB3176938",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3176938"
     },
     {
       "full_version": "10.0.10586.589",
@@ -219,7 +219,7 @@
       "kb_article": "KB3185614",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3185614"
     },
     {
       "full_version": "10.0.14393.187",
@@ -231,7 +231,7 @@
       "kb_article": "KB3189866",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3189866"
     },
     {
       "full_version": "10.0.14393.187",
@@ -243,7 +243,7 @@
       "kb_article": "KB3189866",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3189866"
     },
     {
       "full_version": "10.0.14393.189",
@@ -255,7 +255,7 @@
       "kb_article": "KB3189866",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3189866"
     },
     {
       "full_version": "10.0.14393.189",
@@ -267,7 +267,7 @@
       "kb_article": "KB3189866",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3189866"
     },
     {
       "full_version": "10.0.14393.222",
@@ -279,7 +279,7 @@
       "kb_article": "KB3194496",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3194496"
     },
     {
       "full_version": "10.0.14393.222",
@@ -291,7 +291,7 @@
       "kb_article": "KB3194496",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3194496"
     },
     {
       "full_version": "10.0.10586.633",
@@ -303,7 +303,7 @@
       "kb_article": "KB3192441",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3192441"
     },
     {
       "full_version": "10.0.14393.321",
@@ -315,7 +315,7 @@
       "kb_article": "KB3194798",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3194798"
     },
     {
       "full_version": "10.0.14393.321",
@@ -327,7 +327,7 @@
       "kb_article": "KB3194798",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3194798"
     },
     {
       "full_version": "10.0.14393.351",
@@ -339,7 +339,7 @@
       "kb_article": "KB3197954",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3197954"
     },
     {
       "full_version": "10.0.14393.351",
@@ -351,7 +351,7 @@
       "kb_article": "KB3197954",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3197954"
     },
     {
       "full_version": "10.0.10586.679",
@@ -363,7 +363,7 @@
       "kb_article": "KB3198586",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3198586"
     },
     {
       "full_version": "10.0.14393.447",
@@ -375,7 +375,7 @@
       "kb_article": "KB3200970",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3200970"
     },
     {
       "full_version": "10.0.14393.447",
@@ -387,7 +387,7 @@
       "kb_article": "KB3200970",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3200970"
     },
     {
       "full_version": "10.0.14393.448",
@@ -399,7 +399,7 @@
       "kb_article": "KB3200970",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3200970"
     },
     {
       "full_version": "10.0.14393.448",
@@ -411,7 +411,7 @@
       "kb_article": "KB3200970",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3200970"
     },
     {
       "full_version": "10.0.10586.682",
@@ -423,7 +423,7 @@
       "kb_article": "KB3198586",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3198586"
     },
     {
       "full_version": "10.0.14393.479",
@@ -435,7 +435,7 @@
       "kb_article": "KB3201845",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3201845"
     },
     {
       "full_version": "10.0.14393.479",
@@ -447,7 +447,7 @@
       "kb_article": "KB3201845",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3201845"
     },
     {
       "full_version": "10.0.10586.713",
@@ -459,7 +459,7 @@
       "kb_article": "KB3205386",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3205386"
     },
     {
       "full_version": "10.0.14393.571",
@@ -471,7 +471,7 @@
       "kb_article": "KB3206632",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3206632"
     },
     {
       "full_version": "10.0.14393.571",
@@ -483,7 +483,7 @@
       "kb_article": "KB3206632",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3206632"
     },
     {
       "full_version": "10.0.10586.753",
@@ -495,7 +495,7 @@
       "kb_article": "KB3210721",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3210721"
     },
     {
       "full_version": "10.0.14393.693",
@@ -507,7 +507,7 @@
       "kb_article": "KB3213986",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3213986"
     },
     {
       "full_version": "10.0.14393.693",
@@ -519,7 +519,7 @@
       "kb_article": "KB3213986",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/3213986"
     },
     {
       "full_version": "10.0.14393.729",
@@ -531,7 +531,7 @@
       "kb_article": "KB4010672",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4010672"
     },
     {
       "full_version": "10.0.14393.729",
@@ -543,7 +543,7 @@
       "kb_article": "KB4010672",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4010672"
     },
     {
       "full_version": "10.0.10586.839",
@@ -555,7 +555,7 @@
       "kb_article": "KB4013198",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4013198"
     },
     {
       "full_version": "10.0.14393.953",
@@ -567,7 +567,7 @@
       "kb_article": "KB4013429",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4013429"
     },
     {
       "full_version": "10.0.14393.953",
@@ -579,7 +579,7 @@
       "kb_article": "KB4013429",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4013429"
     },
     {
       "full_version": "10.0.14393.969",
@@ -591,7 +591,7 @@
       "kb_article": "KB4015438",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015438"
     },
     {
       "full_version": "10.0.14393.969",
@@ -603,7 +603,7 @@
       "kb_article": "KB4015438",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015438"
     },
     {
       "full_version": "10.0.10586.842",
@@ -615,7 +615,7 @@
       "kb_article": "KB4016636",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016636"
     },
     {
       "full_version": "10.0.14393.970",
@@ -627,7 +627,7 @@
       "kb_article": "KB4016635",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016635"
     },
     {
       "full_version": "10.0.14393.970",
@@ -639,7 +639,7 @@
       "kb_article": "KB4016635",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016635"
     },
     {
       "full_version": "10.0.15063.13",
@@ -651,7 +651,7 @@
       "kb_article": "KB4016251",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016251"
     },
     {
       "full_version": "10.0.10586.873",
@@ -663,7 +663,7 @@
       "kb_article": "KB4015219",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015219"
     },
     {
       "full_version": "10.0.14393.1066",
@@ -675,7 +675,7 @@
       "kb_article": "KB4015217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015217"
     },
     {
       "full_version": "10.0.14393.1066",
@@ -687,7 +687,7 @@
       "kb_article": "KB4015217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015217"
     },
     {
       "full_version": "10.0.14393.1083",
@@ -699,7 +699,7 @@
       "kb_article": "KB4015217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015217"
     },
     {
       "full_version": "10.0.14393.1083",
@@ -711,7 +711,7 @@
       "kb_article": "KB4015217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015217"
     },
     {
       "full_version": "10.0.15063.138",
@@ -723,7 +723,7 @@
       "kb_article": "KB4015583",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4015583"
     },
     {
       "full_version": "10.0.15063.250",
@@ -735,7 +735,7 @@
       "kb_article": "KB4016240",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016240"
     },
     {
       "full_version": "10.0.10586.916",
@@ -747,7 +747,7 @@
       "kb_article": "KB4019473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4019473"
     },
     {
       "full_version": "10.0.14393.1198",
@@ -759,7 +759,7 @@
       "kb_article": "KB4019472",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4019472"
     },
     {
       "full_version": "10.0.14393.1198",
@@ -771,7 +771,7 @@
       "kb_article": "KB4019472",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4019472"
     },
     {
       "full_version": "10.0.15063.296",
@@ -783,7 +783,7 @@
       "kb_article": "KB4016871",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016871"
     },
     {
       "full_version": "10.0.15063.297",
@@ -795,7 +795,7 @@
       "kb_article": "KB4016871",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4016871"
     },
     {
       "full_version": "10.0.15063.332",
@@ -807,7 +807,7 @@
       "kb_article": "KB4020102",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4020102"
     },
     {
       "full_version": "10.0.14393.1230",
@@ -819,7 +819,7 @@
       "kb_article": "KB4023680",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4023680"
     },
     {
       "full_version": "10.0.14393.1230",
@@ -831,7 +831,7 @@
       "kb_article": "KB4023680",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4023680"
     },
     {
       "full_version": "10.0.10586.962",
@@ -843,7 +843,7 @@
       "kb_article": "KB4022714",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022714"
     },
     {
       "full_version": "10.0.14393.1358",
@@ -855,7 +855,7 @@
       "kb_article": "KB4022715",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022715"
     },
     {
       "full_version": "10.0.14393.1358",
@@ -867,7 +867,7 @@
       "kb_article": "KB4022715",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022715"
     },
     {
       "full_version": "10.0.15063.413",
@@ -879,7 +879,7 @@
       "kb_article": "KB4022725",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022725"
     },
     {
       "full_version": "10.0.15063.414",
@@ -891,7 +891,7 @@
       "kb_article": "KB4022725",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022725"
     },
     {
       "full_version": "10.0.10586.965",
@@ -903,7 +903,7 @@
       "kb_article": "KB4032693",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4032693"
     },
     {
       "full_version": "10.0.14393.1378",
@@ -915,7 +915,7 @@
       "kb_article": "KB4022723",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022723"
     },
     {
       "full_version": "10.0.14393.1378",
@@ -927,7 +927,7 @@
       "kb_article": "KB4022723",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022723"
     },
     {
       "full_version": "10.0.15063.447",
@@ -939,7 +939,7 @@
       "kb_article": "KB4022716",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4022716"
     },
     {
       "full_version": "10.0.10586.1007",
@@ -951,7 +951,7 @@
       "kb_article": "KB4025344",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025344"
     },
     {
       "full_version": "10.0.14393.1480",
@@ -963,7 +963,7 @@
       "kb_article": "KB4025339",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025339"
     },
     {
       "full_version": "10.0.14393.1480",
@@ -975,7 +975,7 @@
       "kb_article": "KB4025339",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025339"
     },
     {
       "full_version": "10.0.15063.483",
@@ -987,7 +987,7 @@
       "kb_article": "KB4025342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025342"
     },
     {
       "full_version": "10.0.14393.1532",
@@ -999,7 +999,7 @@
       "kb_article": "KB4025334",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025334"
     },
     {
       "full_version": "10.0.14393.1532",
@@ -1011,7 +1011,7 @@
       "kb_article": "KB4025334",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4025334"
     },
     {
       "full_version": "10.0.15063.502",
@@ -1023,7 +1023,7 @@
       "kb_article": "KB4032188",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4032188"
     },
     {
       "full_version": "10.0.14393.1537",
@@ -1035,7 +1035,7 @@
       "kb_article": "KB4038220",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038220"
     },
     {
       "full_version": "10.0.14393.1537",
@@ -1047,7 +1047,7 @@
       "kb_article": "KB4038220",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038220"
     },
     {
       "full_version": "10.0.10586.1045",
@@ -1059,7 +1059,7 @@
       "kb_article": "KB4034660",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034660"
     },
     {
       "full_version": "10.0.14393.1593",
@@ -1071,7 +1071,7 @@
       "kb_article": "KB4034658",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034658"
     },
     {
       "full_version": "10.0.14393.1593",
@@ -1083,7 +1083,7 @@
       "kb_article": "KB4034658",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034658"
     },
     {
       "full_version": "10.0.15063.540",
@@ -1095,7 +1095,7 @@
       "kb_article": "KB4034674",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034674"
     },
     {
       "full_version": "10.0.14393.1613",
@@ -1107,7 +1107,7 @@
       "kb_article": "KB4034661",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034661"
     },
     {
       "full_version": "10.0.14393.1613",
@@ -1119,7 +1119,7 @@
       "kb_article": "KB4034661",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4034661"
     },
     {
       "full_version": "10.0.14393.1670",
@@ -1131,7 +1131,7 @@
       "kb_article": "KB4039396",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4039396"
     },
     {
       "full_version": "10.0.14393.1670",
@@ -1143,7 +1143,7 @@
       "kb_article": "KB4039396",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4039396"
     },
     {
       "full_version": "10.0.10586.1106",
@@ -1155,7 +1155,7 @@
       "kb_article": "KB4038783",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038783"
     },
     {
       "full_version": "10.0.14393.1715",
@@ -1167,7 +1167,7 @@
       "kb_article": "KB4038782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038782"
     },
     {
       "full_version": "10.0.14393.1715",
@@ -1179,7 +1179,7 @@
       "kb_article": "KB4038782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038782"
     },
     {
       "full_version": "10.0.15063.608",
@@ -1191,7 +1191,7 @@
       "kb_article": "KB4038788",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038788"
     },
     {
       "full_version": "10.0.15063.632",
@@ -1203,7 +1203,7 @@
       "kb_article": "KB4040724",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4040724"
     },
     {
       "full_version": "10.0.14393.1737",
@@ -1215,7 +1215,7 @@
       "kb_article": "KB4038801",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038801"
     },
     {
       "full_version": "10.0.14393.1737",
@@ -1227,7 +1227,7 @@
       "kb_article": "KB4038801",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4038801"
     },
     {
       "full_version": "10.0.10586.1176",
@@ -1239,7 +1239,7 @@
       "kb_article": "KB4041689",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041689"
     },
     {
       "full_version": "10.0.14393.1770",
@@ -1251,7 +1251,7 @@
       "kb_article": "KB4041691",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041691"
     },
     {
       "full_version": "10.0.14393.1770",
@@ -1263,7 +1263,7 @@
       "kb_article": "KB4041691",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041691"
     },
     {
       "full_version": "10.0.15063.674",
@@ -1275,7 +1275,7 @@
       "kb_article": "KB4041676",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041676"
     },
     {
       "full_version": "10.0.14393.1794",
@@ -1287,7 +1287,7 @@
       "kb_article": "KB4041688",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041688"
     },
     {
       "full_version": "10.0.14393.1794",
@@ -1299,7 +1299,7 @@
       "kb_article": "KB4041688",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4041688"
     },
     {
       "full_version": "10.0.16299.19",
@@ -1311,7 +1311,7 @@
       "kb_article": "KB4043961",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4043961"
     },
     {
       "full_version": "10.0.10586.1177",
@@ -1323,7 +1323,7 @@
       "kb_article": "KB4052232",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4052232"
     },
     {
       "full_version": "10.0.14393.1797",
@@ -1335,7 +1335,7 @@
       "kb_article": "KB4052231",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4052231"
     },
     {
       "full_version": "10.0.14393.1797",
@@ -1347,7 +1347,7 @@
       "kb_article": "KB4052231",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4052231"
     },
     {
       "full_version": "10.0.15063.675",
@@ -1359,7 +1359,7 @@
       "kb_article": "KB4049370",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4049370"
     },
     {
       "full_version": "10.0.10586.1232",
@@ -1371,7 +1371,7 @@
       "kb_article": "KB4048952",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048952"
     },
     {
       "full_version": "10.0.14393.1884",
@@ -1383,7 +1383,7 @@
       "kb_article": "KB4048953",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048953"
     },
     {
       "full_version": "10.0.14393.1884",
@@ -1395,7 +1395,7 @@
       "kb_article": "KB4048953",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048953"
     },
     {
       "full_version": "10.0.15063.726",
@@ -1407,7 +1407,7 @@
       "kb_article": "KB4048954",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048954"
     },
     {
       "full_version": "10.0.15063.728",
@@ -1419,7 +1419,7 @@
       "kb_article": "KB4048954",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048954"
     },
     {
       "full_version": "10.0.16299.64",
@@ -1431,7 +1431,7 @@
       "kb_article": "KB4048955",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4048955"
     },
     {
       "full_version": "10.0.15063.729",
@@ -1443,7 +1443,7 @@
       "kb_article": "KB4055254",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4055254"
     },
     {
       "full_version": "10.0.14393.1914",
@@ -1455,7 +1455,7 @@
       "kb_article": "KB4051033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4051033"
     },
     {
       "full_version": "10.0.14393.1914",
@@ -1467,7 +1467,7 @@
       "kb_article": "KB4051033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4051033"
     },
     {
       "full_version": "10.0.16299.98",
@@ -1479,7 +1479,7 @@
       "kb_article": "KB4051963",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4051963"
     },
     {
       "full_version": "10.0.10586.1295",
@@ -1491,7 +1491,7 @@
       "kb_article": "KB4053578",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4053578"
     },
     {
       "full_version": "10.0.14393.1944",
@@ -1503,7 +1503,7 @@
       "kb_article": "KB4053579",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4053579"
     },
     {
       "full_version": "10.0.14393.1944",
@@ -1515,7 +1515,7 @@
       "kb_article": "KB4053579",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4053579"
     },
     {
       "full_version": "10.0.15063.786",
@@ -1527,7 +1527,7 @@
       "kb_article": "KB4053580",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4053580"
     },
     {
       "full_version": "10.0.16299.125",
@@ -1539,7 +1539,7 @@
       "kb_article": "KB4054517",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4054517"
     },
     {
       "full_version": "10.0.10586.1356",
@@ -1551,7 +1551,7 @@
       "kb_article": "KB4056888",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4056888"
     },
     {
       "full_version": "10.0.14393.2007",
@@ -1563,7 +1563,7 @@
       "kb_article": "KB4056890",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4056890"
     },
     {
       "full_version": "10.0.14393.2007",
@@ -1575,7 +1575,7 @@
       "kb_article": "KB4056890",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4056890"
     },
     {
       "full_version": "10.0.15063.850",
@@ -1587,7 +1587,7 @@
       "kb_article": "KB4056891",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4056891"
     },
     {
       "full_version": "10.0.16299.192",
@@ -1599,7 +1599,7 @@
       "kb_article": "KB4056892",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4056892"
     },
     {
       "full_version": "10.0.14393.2034",
@@ -1611,7 +1611,7 @@
       "kb_article": "KB4057142",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4057142"
     },
     {
       "full_version": "10.0.14393.2034",
@@ -1623,7 +1623,7 @@
       "kb_article": "KB4057142",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4057142"
     },
     {
       "full_version": "10.0.15063.877",
@@ -1635,7 +1635,7 @@
       "kb_article": "KB4057144",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4057144"
     },
     {
       "full_version": "10.0.10586.1358",
@@ -1647,7 +1647,7 @@
       "kb_article": "KB4075200",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4075200"
     },
     {
       "full_version": "10.0.16299.201",
@@ -1659,7 +1659,7 @@
       "kb_article": "KB4073291",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4073291"
     },
     {
       "full_version": "10.0.16299.214",
@@ -1671,7 +1671,7 @@
       "kb_article": "KB4058258",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4058258"
     },
     {
       "full_version": "10.0.10586.1417",
@@ -1683,7 +1683,7 @@
       "kb_article": "KB4074591",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4074591"
     },
     {
       "full_version": "10.0.14393.2068",
@@ -1695,7 +1695,7 @@
       "kb_article": "KB4074590",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4074590"
     },
     {
       "full_version": "10.0.14393.2068",
@@ -1707,7 +1707,7 @@
       "kb_article": "KB4074590",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4074590"
     },
     {
       "full_version": "10.0.15063.909",
@@ -1719,7 +1719,7 @@
       "kb_article": "KB4074592",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4074592"
     },
     {
       "full_version": "10.0.16299.248",
@@ -1731,7 +1731,7 @@
       "kb_article": "KB4074588",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4074588"
     },
     {
       "full_version": "10.0.14393.2097",
@@ -1743,7 +1743,7 @@
       "kb_article": "KB4077525",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4077525"
     },
     {
       "full_version": "10.0.14393.2097",
@@ -1755,7 +1755,7 @@
       "kb_article": "KB4077525",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4077525"
     },
     {
       "full_version": "10.0.15063.936",
@@ -1767,7 +1767,7 @@
       "kb_article": "KB4077528",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4077528"
     },
     {
       "full_version": "10.0.16299.251",
@@ -1779,7 +1779,7 @@
       "kb_article": "KB4090913",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4090913"
     },
     {
       "full_version": "10.0.10586.1478",
@@ -1791,7 +1791,7 @@
       "kb_article": "KB4088779",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088779"
     },
     {
       "full_version": "10.0.14393.2125",
@@ -1803,7 +1803,7 @@
       "kb_article": "KB4088787",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088787"
     },
     {
       "full_version": "10.0.14393.2125",
@@ -1815,7 +1815,7 @@
       "kb_article": "KB4088787",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088787"
     },
     {
       "full_version": "10.0.14393.2126",
@@ -1827,7 +1827,7 @@
       "kb_article": "KB4088787",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088787"
     },
     {
       "full_version": "10.0.14393.2126",
@@ -1839,7 +1839,7 @@
       "kb_article": "KB4088787",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088787"
     },
     {
       "full_version": "10.0.15063.966",
@@ -1851,7 +1851,7 @@
       "kb_article": "KB4088782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088782"
     },
     {
       "full_version": "10.0.15063.968",
@@ -1863,7 +1863,7 @@
       "kb_article": "KB4088782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088782"
     },
     {
       "full_version": "10.0.16299.309",
@@ -1875,7 +1875,7 @@
       "kb_article": "KB4088776",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088776"
     },
     {
       "full_version": "10.0.14393.2155",
@@ -1887,7 +1887,7 @@
       "kb_article": "KB4088889",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088889"
     },
     {
       "full_version": "10.0.14393.2155",
@@ -1899,7 +1899,7 @@
       "kb_article": "KB4088889",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088889"
     },
     {
       "full_version": "10.0.15063.994",
@@ -1911,7 +1911,7 @@
       "kb_article": "KB4088891",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4088891"
     },
     {
       "full_version": "10.0.16299.334",
@@ -1923,7 +1923,7 @@
       "kb_article": "KB4089848",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4089848"
     },
     {
       "full_version": "10.0.14393.2156",
@@ -1935,7 +1935,7 @@
       "kb_article": "KB4096309",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4096309"
     },
     {
       "full_version": "10.0.14393.2156",
@@ -1947,7 +1947,7 @@
       "kb_article": "KB4096309",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4096309"
     },
     {
       "full_version": "10.0.10586.1540",
@@ -1959,7 +1959,7 @@
       "kb_article": "KB4093109",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093109"
     },
     {
       "full_version": "10.0.14393.2189",
@@ -1971,7 +1971,7 @@
       "kb_article": "KB4093119",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093119"
     },
     {
       "full_version": "10.0.14393.2189",
@@ -1983,7 +1983,7 @@
       "kb_article": "KB4093119",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093119"
     },
     {
       "full_version": "10.0.15063.1029",
@@ -1995,7 +1995,7 @@
       "kb_article": "KB4093107",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093107"
     },
     {
       "full_version": "10.0.16299.371",
@@ -2007,7 +2007,7 @@
       "kb_article": "KB4093112",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093112"
     },
     {
       "full_version": "10.0.14393.2214",
@@ -2019,7 +2019,7 @@
       "kb_article": "KB4093120",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093120"
     },
     {
       "full_version": "10.0.14393.2214",
@@ -2031,7 +2031,7 @@
       "kb_article": "KB4093120",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093120"
     },
     {
       "full_version": "10.0.15063.1058",
@@ -2043,7 +2043,7 @@
       "kb_article": "KB4093117",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093117"
     },
     {
       "full_version": "10.0.16299.402",
@@ -2055,7 +2055,7 @@
       "kb_article": "KB4093105",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4093105"
     },
     {
       "full_version": "10.0.14393.2248",
@@ -2067,7 +2067,7 @@
       "kb_article": "KB4103723",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103723"
     },
     {
       "full_version": "10.0.14393.2248",
@@ -2079,7 +2079,7 @@
       "kb_article": "KB4103723",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103723"
     },
     {
       "full_version": "10.0.15063.1088",
@@ -2091,7 +2091,7 @@
       "kb_article": "KB4103731",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103731"
     },
     {
       "full_version": "10.0.16299.431",
@@ -2103,7 +2103,7 @@
       "kb_article": "KB4103727",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103727"
     },
     {
       "full_version": "10.0.17134.48",
@@ -2115,7 +2115,7 @@
       "kb_article": "KB4103721",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103721"
     },
     {
       "full_version": "10.0.14393.2273",
@@ -2127,7 +2127,7 @@
       "kb_article": "KB4103720",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103720"
     },
     {
       "full_version": "10.0.14393.2273",
@@ -2139,7 +2139,7 @@
       "kb_article": "KB4103720",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103720"
     },
     {
       "full_version": "10.0.15063.1112",
@@ -2151,7 +2151,7 @@
       "kb_article": "KB4103722",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103722"
     },
     {
       "full_version": "10.0.16299.461",
@@ -2163,7 +2163,7 @@
       "kb_article": "KB4103714",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4103714"
     },
     {
       "full_version": "10.0.17134.81",
@@ -2175,7 +2175,7 @@
       "kb_article": "KB4100403",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4100403"
     },
     {
       "full_version": "10.0.17134.83",
@@ -2187,7 +2187,7 @@
       "kb_article": "KB4338548",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338548"
     },
     {
       "full_version": "10.0.14393.2312",
@@ -2199,7 +2199,7 @@
       "kb_article": "KB4284880",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284880"
     },
     {
       "full_version": "10.0.14393.2312",
@@ -2211,7 +2211,7 @@
       "kb_article": "KB4284880",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284880"
     },
     {
       "full_version": "10.0.15063.1155",
@@ -2223,7 +2223,7 @@
       "kb_article": "KB4284874",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284874"
     },
     {
       "full_version": "10.0.16299.492",
@@ -2235,7 +2235,7 @@
       "kb_article": "KB4284819",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284819"
     },
     {
       "full_version": "10.0.17134.112",
@@ -2247,7 +2247,7 @@
       "kb_article": "KB4284835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284835"
     },
     {
       "full_version": "10.0.14393.2339",
@@ -2259,7 +2259,7 @@
       "kb_article": "KB4284833",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284833"
     },
     {
       "full_version": "10.0.14393.2339",
@@ -2271,7 +2271,7 @@
       "kb_article": "KB4284833",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284833"
     },
     {
       "full_version": "10.0.15063.1182",
@@ -2283,7 +2283,7 @@
       "kb_article": "KB4284830",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284830"
     },
     {
       "full_version": "10.0.16299.522",
@@ -2295,7 +2295,7 @@
       "kb_article": "KB4284822",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284822"
     },
     {
       "full_version": "10.0.17134.137",
@@ -2307,7 +2307,7 @@
       "kb_article": "KB4284848",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4284848"
     },
     {
       "full_version": "10.0.14393.2363",
@@ -2319,7 +2319,7 @@
       "kb_article": "KB4338814",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338814"
     },
     {
       "full_version": "10.0.14393.2363",
@@ -2331,7 +2331,7 @@
       "kb_article": "KB4338814",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338814"
     },
     {
       "full_version": "10.0.15063.1206",
@@ -2343,7 +2343,7 @@
       "kb_article": "KB4338826",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338826"
     },
     {
       "full_version": "10.0.16299.547",
@@ -2355,7 +2355,7 @@
       "kb_article": "KB4338825",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338825"
     },
     {
       "full_version": "10.0.17134.165",
@@ -2367,7 +2367,7 @@
       "kb_article": "KB4338819",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338819"
     },
     {
       "full_version": "10.0.14393.2368",
@@ -2379,7 +2379,7 @@
       "kb_article": "KB4345418",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4345418"
     },
     {
       "full_version": "10.0.14393.2368",
@@ -2391,7 +2391,7 @@
       "kb_article": "KB4345418",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4345418"
     },
     {
       "full_version": "10.0.15063.1209",
@@ -2403,7 +2403,7 @@
       "kb_article": "KB4345419",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4345419"
     },
     {
       "full_version": "10.0.16299.551",
@@ -2415,7 +2415,7 @@
       "kb_article": "KB4345420",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4345420"
     },
     {
       "full_version": "10.0.17134.167",
@@ -2427,7 +2427,7 @@
       "kb_article": "KB4345421",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4345421"
     },
     {
       "full_version": "10.0.14393.2395",
@@ -2439,7 +2439,7 @@
       "kb_article": "KB4338822",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338822"
     },
     {
       "full_version": "10.0.14393.2395",
@@ -2451,7 +2451,7 @@
       "kb_article": "KB4338822",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338822"
     },
     {
       "full_version": "10.0.15063.1235",
@@ -2463,7 +2463,7 @@
       "kb_article": "KB4338827",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338827"
     },
     {
       "full_version": "10.0.16299.579",
@@ -2475,7 +2475,7 @@
       "kb_article": "KB4338817",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4338817"
     },
     {
       "full_version": "10.0.17134.191",
@@ -2487,7 +2487,7 @@
       "kb_article": "KB4340917",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4340917"
     },
     {
       "full_version": "10.0.14393.2396",
@@ -2499,7 +2499,7 @@
       "kb_article": "KB4346877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4346877"
     },
     {
       "full_version": "10.0.14393.2396",
@@ -2511,7 +2511,7 @@
       "kb_article": "KB4346877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4346877"
     },
     {
       "full_version": "10.0.14393.2430",
@@ -2523,7 +2523,7 @@
       "kb_article": "KB4343887",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343887"
     },
     {
       "full_version": "10.0.14393.2430",
@@ -2535,7 +2535,7 @@
       "kb_article": "KB4343887",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343887"
     },
     {
       "full_version": "10.0.15063.1266",
@@ -2547,7 +2547,7 @@
       "kb_article": "KB4343885",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343885"
     },
     {
       "full_version": "10.0.16299.611",
@@ -2559,7 +2559,7 @@
       "kb_article": "KB4343897",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343897"
     },
     {
       "full_version": "10.0.17134.228",
@@ -2571,7 +2571,7 @@
       "kb_article": "KB4343909",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343909"
     },
     {
       "full_version": "10.0.14393.2457",
@@ -2583,7 +2583,7 @@
       "kb_article": "KB4343884",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343884"
     },
     {
       "full_version": "10.0.14393.2457",
@@ -2595,7 +2595,7 @@
       "kb_article": "KB4343884",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343884"
     },
     {
       "full_version": "10.0.15063.1292",
@@ -2607,7 +2607,7 @@
       "kb_article": "KB4343889",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343889"
     },
     {
       "full_version": "10.0.16299.637",
@@ -2619,7 +2619,7 @@
       "kb_article": "KB4343893",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4343893"
     },
     {
       "full_version": "10.0.17134.254",
@@ -2631,7 +2631,7 @@
       "kb_article": "KB4346783",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4346783"
     },
     {
       "full_version": "10.0.14393.2485",
@@ -2643,7 +2643,7 @@
       "kb_article": "KB4457131",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457131"
     },
     {
       "full_version": "10.0.14393.2485",
@@ -2655,7 +2655,7 @@
       "kb_article": "KB4457131",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457131"
     },
     {
       "full_version": "10.0.15063.1324",
@@ -2667,7 +2667,7 @@
       "kb_article": "KB4457138",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457138"
     },
     {
       "full_version": "10.0.16299.665",
@@ -2679,7 +2679,7 @@
       "kb_article": "KB4457142",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457142"
     },
     {
       "full_version": "10.0.17134.285",
@@ -2691,7 +2691,7 @@
       "kb_article": "KB4457128",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457128"
     },
     {
       "full_version": "10.0.16299.666",
@@ -2703,7 +2703,7 @@
       "kb_article": "KB4464217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464217"
     },
     {
       "full_version": "10.0.17134.286",
@@ -2715,7 +2715,7 @@
       "kb_article": "KB4464218",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464218"
     },
     {
       "full_version": "10.0.14393.2515",
@@ -2727,7 +2727,7 @@
       "kb_article": "KB4457127",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457127"
     },
     {
       "full_version": "10.0.14393.2515",
@@ -2739,7 +2739,7 @@
       "kb_article": "KB4457127",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457127"
     },
     {
       "full_version": "10.0.15063.1358",
@@ -2751,7 +2751,7 @@
       "kb_article": "KB4457141",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457141"
     },
     {
       "full_version": "10.0.16299.699",
@@ -2763,7 +2763,7 @@
       "kb_article": "KB4457136",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4457136"
     },
     {
       "full_version": "10.0.17134.320",
@@ -2775,7 +2775,7 @@
       "kb_article": "KB4458469",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4458469"
     },
     {
       "full_version": "10.0.14393.2551",
@@ -2787,7 +2787,7 @@
       "kb_article": "KB4462917",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462917"
     },
     {
       "full_version": "10.0.14393.2551",
@@ -2799,7 +2799,7 @@
       "kb_article": "KB4462917",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462917"
     },
     {
       "full_version": "10.0.15063.1387",
@@ -2811,7 +2811,7 @@
       "kb_article": "KB4462937",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462937"
     },
     {
       "full_version": "10.0.16299.726",
@@ -2823,7 +2823,7 @@
       "kb_article": "KB4462918",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462918"
     },
     {
       "full_version": "10.0.17134.345",
@@ -2835,7 +2835,7 @@
       "kb_article": "KB4462919",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462919"
     },
     {
       "full_version": "10.0.17763.55",
@@ -2847,7 +2847,7 @@
       "kb_article": "KB4464330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464330"
     },
     {
       "full_version": "10.0.17763.55",
@@ -2859,7 +2859,7 @@
       "kb_article": "KB4464330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464330"
     },
     {
       "full_version": "10.0.14393.2580",
@@ -2871,7 +2871,7 @@
       "kb_article": "KB4462928",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462928"
     },
     {
       "full_version": "10.0.14393.2580",
@@ -2883,7 +2883,7 @@
       "kb_article": "KB4462928",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462928"
     },
     {
       "full_version": "10.0.15063.1418",
@@ -2895,7 +2895,7 @@
       "kb_article": "KB4462939",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462939"
     },
     {
       "full_version": "10.0.16299.755",
@@ -2907,7 +2907,7 @@
       "kb_article": "KB4462932",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462932"
     },
     {
       "full_version": "10.0.17134.376",
@@ -2919,7 +2919,7 @@
       "kb_article": "KB4462933",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4462933"
     },
     {
       "full_version": "10.0.14393.2608",
@@ -2931,7 +2931,7 @@
       "kb_article": "KB4467691",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467691"
     },
     {
       "full_version": "10.0.14393.2608",
@@ -2943,7 +2943,7 @@
       "kb_article": "KB4467691",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467691"
     },
     {
       "full_version": "10.0.15063.1446",
@@ -2955,7 +2955,7 @@
       "kb_article": "KB4467696",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467696"
     },
     {
       "full_version": "10.0.16299.785",
@@ -2967,7 +2967,7 @@
       "kb_article": "KB4467686",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467686"
     },
     {
       "full_version": "10.0.17134.407",
@@ -2979,7 +2979,7 @@
       "kb_article": "KB4467702",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467702"
     },
     {
       "full_version": "10.0.17763.107",
@@ -2991,7 +2991,7 @@
       "kb_article": "KB4464455",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464455"
     },
     {
       "full_version": "10.0.17763.107",
@@ -3003,7 +3003,7 @@
       "kb_article": "KB4464455",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4464455"
     },
     {
       "full_version": "10.0.17763.134",
@@ -3015,7 +3015,7 @@
       "kb_article": "KB4467708",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467708"
     },
     {
       "full_version": "10.0.17763.134",
@@ -3027,7 +3027,7 @@
       "kb_article": "KB4467708",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467708"
     },
     {
       "full_version": "10.0.14393.2639",
@@ -3039,7 +3039,7 @@
       "kb_article": "KB4467684",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467684"
     },
     {
       "full_version": "10.0.14393.2639",
@@ -3051,7 +3051,7 @@
       "kb_article": "KB4467684",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467684"
     },
     {
       "full_version": "10.0.15063.1478",
@@ -3063,7 +3063,7 @@
       "kb_article": "KB4467699",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467699"
     },
     {
       "full_version": "10.0.16299.820",
@@ -3075,7 +3075,7 @@
       "kb_article": "KB4467681",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467681"
     },
     {
       "full_version": "10.0.17134.441",
@@ -3087,7 +3087,7 @@
       "kb_article": "KB4467682",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4467682"
     },
     {
       "full_version": "10.0.14393.2641",
@@ -3099,7 +3099,7 @@
       "kb_article": "KB4478877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4478877"
     },
     {
       "full_version": "10.0.14393.2641",
@@ -3111,7 +3111,7 @@
       "kb_article": "KB4478877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4478877"
     },
     {
       "full_version": "10.0.17763.168",
@@ -3123,7 +3123,7 @@
       "kb_article": "KB4469342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4469342"
     },
     {
       "full_version": "10.0.17763.168",
@@ -3135,7 +3135,7 @@
       "kb_article": "KB4469342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4469342"
     },
     {
       "full_version": "10.0.14393.2665",
@@ -3147,7 +3147,7 @@
       "kb_article": "KB4471321",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471321"
     },
     {
       "full_version": "10.0.14393.2665",
@@ -3159,7 +3159,7 @@
       "kb_article": "KB4471321",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471321"
     },
     {
       "full_version": "10.0.15063.1506",
@@ -3171,7 +3171,7 @@
       "kb_article": "KB4471327",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471327"
     },
     {
       "full_version": "10.0.16299.846",
@@ -3183,7 +3183,7 @@
       "kb_article": "KB4471329",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471329"
     },
     {
       "full_version": "10.0.17134.471",
@@ -3195,7 +3195,7 @@
       "kb_article": "KB4471324",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471324"
     },
     {
       "full_version": "10.0.17763.194",
@@ -3207,7 +3207,7 @@
       "kb_article": "KB4471332",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471332"
     },
     {
       "full_version": "10.0.17763.194",
@@ -3219,7 +3219,7 @@
       "kb_article": "KB4471332",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4471332"
     },
     {
       "full_version": "10.0.14393.2670",
@@ -3231,7 +3231,7 @@
       "kb_article": "KB4483229",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483229"
     },
     {
       "full_version": "10.0.14393.2670",
@@ -3243,7 +3243,7 @@
       "kb_article": "KB4483229",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483229"
     },
     {
       "full_version": "10.0.15063.1508",
@@ -3255,7 +3255,7 @@
       "kb_article": "KB4483230",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483230"
     },
     {
       "full_version": "10.0.16299.847",
@@ -3267,7 +3267,7 @@
       "kb_article": "KB4483232",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483232"
     },
     {
       "full_version": "10.0.17134.472",
@@ -3279,7 +3279,7 @@
       "kb_article": "KB4483234",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483234"
     },
     {
       "full_version": "10.0.17763.195",
@@ -3291,7 +3291,7 @@
       "kb_article": "KB4483235",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483235"
     },
     {
       "full_version": "10.0.17763.195",
@@ -3303,7 +3303,7 @@
       "kb_article": "KB4483235",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4483235"
     },
     {
       "full_version": "10.0.14393.2724",
@@ -3315,7 +3315,7 @@
       "kb_article": "KB4480961",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480961"
     },
     {
       "full_version": "10.0.14393.2724",
@@ -3327,7 +3327,7 @@
       "kb_article": "KB4480961",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480961"
     },
     {
       "full_version": "10.0.15063.1563",
@@ -3339,7 +3339,7 @@
       "kb_article": "KB4480973",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480973"
     },
     {
       "full_version": "10.0.16299.904",
@@ -3351,7 +3351,7 @@
       "kb_article": "KB4480978",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480978"
     },
     {
       "full_version": "10.0.17134.523",
@@ -3363,7 +3363,7 @@
       "kb_article": "KB4480966",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480966"
     },
     {
       "full_version": "10.0.17763.253",
@@ -3375,7 +3375,7 @@
       "kb_article": "KB4480116",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480116"
     },
     {
       "full_version": "10.0.17763.253",
@@ -3387,7 +3387,7 @@
       "kb_article": "KB4480116",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480116"
     },
     {
       "full_version": "10.0.15063.1596",
@@ -3399,7 +3399,7 @@
       "kb_article": "KB4480959",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480959"
     },
     {
       "full_version": "10.0.16299.936",
@@ -3411,7 +3411,7 @@
       "kb_article": "KB4480967",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480967"
     },
     {
       "full_version": "10.0.17134.556",
@@ -3423,7 +3423,7 @@
       "kb_article": "KB4480976",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480976"
     },
     {
       "full_version": "10.0.14393.2759",
@@ -3435,7 +3435,7 @@
       "kb_article": "KB4480977",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480977"
     },
     {
       "full_version": "10.0.14393.2759",
@@ -3447,7 +3447,7 @@
       "kb_article": "KB4480977",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4480977"
     },
     {
       "full_version": "10.0.17763.292",
@@ -3459,7 +3459,7 @@
       "kb_article": "KB4476976",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4476976"
     },
     {
       "full_version": "10.0.17763.292",
@@ -3471,7 +3471,7 @@
       "kb_article": "KB4476976",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4476976"
     },
     {
       "full_version": "10.0.14393.2791",
@@ -3483,7 +3483,7 @@
       "kb_article": "KB4487026",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487026"
     },
     {
       "full_version": "10.0.14393.2791",
@@ -3495,7 +3495,7 @@
       "kb_article": "KB4487026",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487026"
     },
     {
       "full_version": "10.0.15063.1631",
@@ -3507,7 +3507,7 @@
       "kb_article": "KB4487020",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487020"
     },
     {
       "full_version": "10.0.16299.967",
@@ -3519,7 +3519,7 @@
       "kb_article": "KB4486996",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4486996"
     },
     {
       "full_version": "10.0.17134.590",
@@ -3531,7 +3531,7 @@
       "kb_article": "KB4487017",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487017"
     },
     {
       "full_version": "10.0.17763.316",
@@ -3543,7 +3543,7 @@
       "kb_article": "KB4487044",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487044"
     },
     {
       "full_version": "10.0.17763.316",
@@ -3555,7 +3555,7 @@
       "kb_article": "KB4487044",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487044"
     },
     {
       "full_version": "10.0.14393.2828",
@@ -3567,7 +3567,7 @@
       "kb_article": "KB4487006",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487006"
     },
     {
       "full_version": "10.0.14393.2828",
@@ -3579,7 +3579,7 @@
       "kb_article": "KB4487006",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487006"
     },
     {
       "full_version": "10.0.15063.1659",
@@ -3591,7 +3591,7 @@
       "kb_article": "KB4487011",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487011"
     },
     {
       "full_version": "10.0.16299.1004",
@@ -3603,7 +3603,7 @@
       "kb_article": "KB4487021",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487021"
     },
     {
       "full_version": "10.0.17134.619",
@@ -3615,7 +3615,7 @@
       "kb_article": "KB4487029",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4487029"
     },
     {
       "full_version": "10.0.17763.348",
@@ -3627,7 +3627,7 @@
       "kb_article": "KB4482887",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4482887"
     },
     {
       "full_version": "10.0.17763.348",
@@ -3639,7 +3639,7 @@
       "kb_article": "KB4482887",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4482887"
     },
     {
       "full_version": "10.0.14393.2848",
@@ -3651,7 +3651,7 @@
       "kb_article": "KB4489882",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489882"
     },
     {
       "full_version": "10.0.14393.2848",
@@ -3663,7 +3663,7 @@
       "kb_article": "KB4489882",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489882"
     },
     {
       "full_version": "10.0.15063.1689",
@@ -3675,7 +3675,7 @@
       "kb_article": "KB4489871",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489871"
     },
     {
       "full_version": "10.0.16299.1029",
@@ -3687,7 +3687,7 @@
       "kb_article": "KB4489886",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489886"
     },
     {
       "full_version": "10.0.17134.648",
@@ -3699,7 +3699,7 @@
       "kb_article": "KB4489868",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489868"
     },
     {
       "full_version": "10.0.17763.379",
@@ -3711,7 +3711,7 @@
       "kb_article": "KB4489899",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489899"
     },
     {
       "full_version": "10.0.17763.379",
@@ -3723,7 +3723,7 @@
       "kb_article": "KB4489899",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489899"
     },
     {
       "full_version": "10.0.14393.2879",
@@ -3735,7 +3735,7 @@
       "kb_article": "KB4489889",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489889"
     },
     {
       "full_version": "10.0.14393.2879",
@@ -3747,7 +3747,7 @@
       "kb_article": "KB4489889",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489889"
     },
     {
       "full_version": "10.0.15063.1716",
@@ -3759,7 +3759,7 @@
       "kb_article": "KB4489888",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489888"
     },
     {
       "full_version": "10.0.16299.1059",
@@ -3771,7 +3771,7 @@
       "kb_article": "KB4489890",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489890"
     },
     {
       "full_version": "10.0.17134.677",
@@ -3783,7 +3783,7 @@
       "kb_article": "KB4489894",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4489894"
     },
     {
       "full_version": "10.0.17763.402",
@@ -3795,7 +3795,7 @@
       "kb_article": "KB4490481",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4490481"
     },
     {
       "full_version": "10.0.17763.402",
@@ -3807,7 +3807,7 @@
       "kb_article": "KB4490481",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4490481"
     },
     {
       "full_version": "10.0.14393.2906",
@@ -3819,7 +3819,7 @@
       "kb_article": "KB4493470",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493470"
     },
     {
       "full_version": "10.0.14393.2906",
@@ -3831,7 +3831,7 @@
       "kb_article": "KB4493470",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493470"
     },
     {
       "full_version": "10.0.15063.1746",
@@ -3843,7 +3843,7 @@
       "kb_article": "KB4493474",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493474"
     },
     {
       "full_version": "10.0.16299.1087",
@@ -3855,7 +3855,7 @@
       "kb_article": "KB4493441",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493441"
     },
     {
       "full_version": "10.0.17134.706",
@@ -3867,7 +3867,7 @@
       "kb_article": "KB4493464",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493464"
     },
     {
       "full_version": "10.0.17763.437",
@@ -3879,7 +3879,7 @@
       "kb_article": "KB4493509",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493509"
     },
     {
       "full_version": "10.0.17763.437",
@@ -3891,7 +3891,7 @@
       "kb_article": "KB4493509",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493509"
     },
     {
       "full_version": "10.0.14393.2941",
@@ -3903,7 +3903,7 @@
       "kb_article": "KB4493473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493473"
     },
     {
       "full_version": "10.0.14393.2941",
@@ -3915,7 +3915,7 @@
       "kb_article": "KB4493473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493473"
     },
     {
       "full_version": "10.0.15063.1784",
@@ -3927,7 +3927,7 @@
       "kb_article": "KB4493436",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493436"
     },
     {
       "full_version": "10.0.16299.1127",
@@ -3939,7 +3939,7 @@
       "kb_article": "KB4493440",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493440"
     },
     {
       "full_version": "10.0.17134.753",
@@ -3951,7 +3951,7 @@
       "kb_article": "KB4493437",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4493437"
     },
     {
       "full_version": "10.0.17763.439",
@@ -3963,7 +3963,7 @@
       "kb_article": "KB4501835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4501835"
     },
     {
       "full_version": "10.0.17763.439",
@@ -3975,7 +3975,7 @@
       "kb_article": "KB4501835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4501835"
     },
     {
       "full_version": "10.0.15063.1785",
@@ -3987,7 +3987,7 @@
       "kb_article": "KB4502112",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4502112"
     },
     {
       "full_version": "10.0.17763.475",
@@ -3999,7 +3999,7 @@
       "kb_article": "KB4495667",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4495667"
     },
     {
       "full_version": "10.0.17763.475",
@@ -4011,7 +4011,7 @@
       "kb_article": "KB4495667",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4495667"
     },
     {
       "full_version": "10.0.14393.2969",
@@ -4023,7 +4023,7 @@
       "kb_article": "KB4494440",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4494440"
     },
     {
       "full_version": "10.0.14393.2969",
@@ -4035,7 +4035,7 @@
       "kb_article": "KB4494440",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4494440"
     },
     {
       "full_version": "10.0.15063.1805",
@@ -4047,7 +4047,7 @@
       "kb_article": "KB4499181",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499181"
     },
     {
       "full_version": "10.0.16299.1146",
@@ -4059,7 +4059,7 @@
       "kb_article": "KB4499179",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499179"
     },
     {
       "full_version": "10.0.17134.765",
@@ -4071,7 +4071,7 @@
       "kb_article": "KB4499167",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499167"
     },
     {
       "full_version": "10.0.17763.503",
@@ -4083,7 +4083,7 @@
       "kb_article": "KB4494441",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4494441"
     },
     {
       "full_version": "10.0.17763.503",
@@ -4095,7 +4095,7 @@
       "kb_article": "KB4494441",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4494441"
     },
     {
       "full_version": "10.0.14393.2972",
@@ -4107,7 +4107,7 @@
       "kb_article": "KB4505052",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505052"
     },
     {
       "full_version": "10.0.14393.2972",
@@ -4119,7 +4119,7 @@
       "kb_article": "KB4505052",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505052"
     },
     {
       "full_version": "10.0.15063.1808",
@@ -4131,7 +4131,7 @@
       "kb_article": "KB4505055",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505055"
     },
     {
       "full_version": "10.0.16299.1150",
@@ -4143,7 +4143,7 @@
       "kb_article": "KB4505062",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505062"
     },
     {
       "full_version": "10.0.17134.766",
@@ -4155,7 +4155,7 @@
       "kb_article": "KB4505064",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505064"
     },
     {
       "full_version": "10.0.17763.504",
@@ -4167,7 +4167,7 @@
       "kb_article": "KB4505056",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505056"
     },
     {
       "full_version": "10.0.17763.504",
@@ -4179,7 +4179,7 @@
       "kb_article": "KB4505056",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505056"
     },
     {
       "full_version": "10.0.17134.799",
@@ -4191,7 +4191,7 @@
       "kb_article": "KB4499183",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499183"
     },
     {
       "full_version": "10.0.14393.2999",
@@ -4203,7 +4203,7 @@
       "kb_article": "KB4499177",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499177"
     },
     {
       "full_version": "10.0.14393.2999",
@@ -4215,7 +4215,7 @@
       "kb_article": "KB4499177",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499177"
     },
     {
       "full_version": "10.0.15063.1839",
@@ -4227,7 +4227,7 @@
       "kb_article": "KB4499162",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499162"
     },
     {
       "full_version": "10.0.16299.1182",
@@ -4239,7 +4239,7 @@
       "kb_article": "KB4499147",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4499147"
     },
     {
       "full_version": "10.0.18362.145",
@@ -4251,7 +4251,7 @@
       "kb_article": "KB4497935",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4497935"
     },
     {
       "full_version": "10.0.14393.3025",
@@ -4263,7 +4263,7 @@
       "kb_article": "KB4503267",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503267"
     },
     {
       "full_version": "10.0.14393.3025",
@@ -4275,7 +4275,7 @@
       "kb_article": "KB4503267",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503267"
     },
     {
       "full_version": "10.0.15063.1868",
@@ -4287,7 +4287,7 @@
       "kb_article": "KB4503279",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503279"
     },
     {
       "full_version": "10.0.16299.1217",
@@ -4299,7 +4299,7 @@
       "kb_article": "KB4503284",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503284"
     },
     {
       "full_version": "10.0.17134.829",
@@ -4311,7 +4311,7 @@
       "kb_article": "KB4503286",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503286"
     },
     {
       "full_version": "10.0.17763.557",
@@ -4323,7 +4323,7 @@
       "kb_article": "KB4503327",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503327"
     },
     {
       "full_version": "10.0.17763.557",
@@ -4335,7 +4335,7 @@
       "kb_article": "KB4503327",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503327"
     },
     {
       "full_version": "10.0.18362.175",
@@ -4347,7 +4347,7 @@
       "kb_article": "KB4503293",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503293"
     },
     {
       "full_version": "10.0.14393.3053",
@@ -4359,7 +4359,7 @@
       "kb_article": "KB4503294",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503294"
     },
     {
       "full_version": "10.0.14393.3053",
@@ -4371,7 +4371,7 @@
       "kb_article": "KB4503294",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503294"
     },
     {
       "full_version": "10.0.15063.1897",
@@ -4383,7 +4383,7 @@
       "kb_article": "KB4503289",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503289"
     },
     {
       "full_version": "10.0.16299.1237",
@@ -4395,7 +4395,7 @@
       "kb_article": "KB4503281",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503281"
     },
     {
       "full_version": "10.0.17134.858",
@@ -4407,7 +4407,7 @@
       "kb_article": "KB4503288",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4503288"
     },
     {
       "full_version": "10.0.17763.592",
@@ -4419,7 +4419,7 @@
       "kb_article": "KB4501371",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4501371"
     },
     {
       "full_version": "10.0.17763.592",
@@ -4431,7 +4431,7 @@
       "kb_article": "KB4501371",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4501371"
     },
     {
       "full_version": "10.0.15063.1898",
@@ -4443,7 +4443,7 @@
       "kb_article": "KB4509476",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509476"
     },
     {
       "full_version": "10.0.16299.1239",
@@ -4455,7 +4455,7 @@
       "kb_article": "KB4509477",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509477"
     },
     {
       "full_version": "10.0.17134.860",
@@ -4467,7 +4467,7 @@
       "kb_article": "KB4509478",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509478"
     },
     {
       "full_version": "10.0.17763.593",
@@ -4479,7 +4479,7 @@
       "kb_article": "KB4509479",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509479"
     },
     {
       "full_version": "10.0.17763.593",
@@ -4491,7 +4491,7 @@
       "kb_article": "KB4509479",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509479"
     },
     {
       "full_version": "10.0.14393.3056",
@@ -4503,7 +4503,7 @@
       "kb_article": "KB4509475",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509475"
     },
     {
       "full_version": "10.0.14393.3056",
@@ -4515,7 +4515,7 @@
       "kb_article": "KB4509475",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4509475"
     },
     {
       "full_version": "10.0.18362.207",
@@ -4527,7 +4527,7 @@
       "kb_article": "KB4501375",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4501375"
     },
     {
       "full_version": "10.0.14393.3085",
@@ -4539,7 +4539,7 @@
       "kb_article": "KB4507460",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507460"
     },
     {
       "full_version": "10.0.14393.3085",
@@ -4551,7 +4551,7 @@
       "kb_article": "KB4507460",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507460"
     },
     {
       "full_version": "10.0.15063.1928",
@@ -4563,7 +4563,7 @@
       "kb_article": "KB4507450",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507450"
     },
     {
       "full_version": "10.0.16299.1268",
@@ -4575,7 +4575,7 @@
       "kb_article": "KB4507455",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507455"
     },
     {
       "full_version": "10.0.17134.885",
@@ -4587,7 +4587,7 @@
       "kb_article": "KB4507435",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507435"
     },
     {
       "full_version": "10.0.17763.615",
@@ -4599,7 +4599,7 @@
       "kb_article": "KB4507469",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507469"
     },
     {
       "full_version": "10.0.17763.615",
@@ -4611,7 +4611,7 @@
       "kb_article": "KB4507469",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507469"
     },
     {
       "full_version": "10.0.18362.239",
@@ -4623,7 +4623,7 @@
       "kb_article": "KB4507453",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507453"
     },
     {
       "full_version": "10.0.14393.3115",
@@ -4635,7 +4635,7 @@
       "kb_article": "KB4507459",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507459"
     },
     {
       "full_version": "10.0.14393.3115",
@@ -4647,7 +4647,7 @@
       "kb_article": "KB4507459",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507459"
     },
     {
       "full_version": "10.0.15063.1955",
@@ -4659,7 +4659,7 @@
       "kb_article": "KB4507467",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507467"
     },
     {
       "full_version": "10.0.16299.1296",
@@ -4671,7 +4671,7 @@
       "kb_article": "KB4507465",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507465"
     },
     {
       "full_version": "10.0.17134.915",
@@ -4683,7 +4683,7 @@
       "kb_article": "KB4507466",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4507466"
     },
     {
       "full_version": "10.0.17763.652",
@@ -4695,7 +4695,7 @@
       "kb_article": "KB4505658",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505658"
     },
     {
       "full_version": "10.0.17763.652",
@@ -4707,7 +4707,7 @@
       "kb_article": "KB4505658",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505658"
     },
     {
       "full_version": "10.0.18362.267",
@@ -4719,7 +4719,7 @@
       "kb_article": "KB4505903",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4505903"
     },
     {
       "full_version": "10.0.14393.3144",
@@ -4731,7 +4731,7 @@
       "kb_article": "KB4512517",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512517"
     },
     {
       "full_version": "10.0.14393.3144",
@@ -4743,7 +4743,7 @@
       "kb_article": "KB4512517",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512517"
     },
     {
       "full_version": "10.0.15063.1988",
@@ -4755,7 +4755,7 @@
       "kb_article": "KB4512507",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512507"
     },
     {
       "full_version": "10.0.16299.1331",
@@ -4767,7 +4767,7 @@
       "kb_article": "KB4512516",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512516"
     },
     {
       "full_version": "10.0.17134.950",
@@ -4779,7 +4779,7 @@
       "kb_article": "KB4512501",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512501"
     },
     {
       "full_version": "10.0.17763.678",
@@ -4791,7 +4791,7 @@
       "kb_article": "KB4511553",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4511553"
     },
     {
       "full_version": "10.0.17763.678",
@@ -4803,7 +4803,7 @@
       "kb_article": "KB4511553",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4511553"
     },
     {
       "full_version": "10.0.18362.295",
@@ -4815,7 +4815,7 @@
       "kb_article": "KB4512508",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512508"
     },
     {
       "full_version": "10.0.16299.1365",
@@ -4827,7 +4827,7 @@
       "kb_article": "KB4512494",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512494"
     },
     {
       "full_version": "10.0.14393.3181",
@@ -4839,7 +4839,7 @@
       "kb_article": "KB4512495",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512495"
     },
     {
       "full_version": "10.0.14393.3181",
@@ -4851,7 +4851,7 @@
       "kb_article": "KB4512495",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512495"
     },
     {
       "full_version": "10.0.15063.2021",
@@ -4863,7 +4863,7 @@
       "kb_article": "KB4512474",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512474"
     },
     {
       "full_version": "10.0.17763.720",
@@ -4875,7 +4875,7 @@
       "kb_article": "KB4512534",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512534"
     },
     {
       "full_version": "10.0.17763.720",
@@ -4887,7 +4887,7 @@
       "kb_article": "KB4512534",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512534"
     },
     {
       "full_version": "10.0.17134.984",
@@ -4899,7 +4899,7 @@
       "kb_article": "KB4512509",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512509"
     },
     {
       "full_version": "10.0.18362.329",
@@ -4911,7 +4911,7 @@
       "kb_article": "KB4512941",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512941"
     },
     {
       "full_version": "10.0.14393.3204",
@@ -4923,7 +4923,7 @@
       "kb_article": "KB4516044",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516044"
     },
     {
       "full_version": "10.0.14393.3204",
@@ -4935,7 +4935,7 @@
       "kb_article": "KB4516044",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516044"
     },
     {
       "full_version": "10.0.15063.2045",
@@ -4947,7 +4947,7 @@
       "kb_article": "KB4516068",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516068"
     },
     {
       "full_version": "10.0.16299.1387",
@@ -4959,7 +4959,7 @@
       "kb_article": "KB4516066",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516066"
     },
     {
       "full_version": "10.0.17134.1006",
@@ -4971,7 +4971,7 @@
       "kb_article": "KB4516058",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516058"
     },
     {
       "full_version": "10.0.17763.737",
@@ -4983,7 +4983,7 @@
       "kb_article": "KB4512578",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512578"
     },
     {
       "full_version": "10.0.17763.737",
@@ -4995,7 +4995,7 @@
       "kb_article": "KB4512578",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4512578"
     },
     {
       "full_version": "10.0.18362.356",
@@ -5007,7 +5007,7 @@
       "kb_article": "KB4515384",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4515384"
     },
     {
       "full_version": "10.0.14393.3206",
@@ -5019,7 +5019,7 @@
       "kb_article": "KB4522010",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522010"
     },
     {
       "full_version": "10.0.14393.3206",
@@ -5031,7 +5031,7 @@
       "kb_article": "KB4522010",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522010"
     },
     {
       "full_version": "10.0.15063.2046",
@@ -5043,7 +5043,7 @@
       "kb_article": "KB4522011",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522011"
     },
     {
       "full_version": "10.0.16299.1392",
@@ -5055,7 +5055,7 @@
       "kb_article": "KB4522012",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522012"
     },
     {
       "full_version": "10.0.17134.1009",
@@ -5067,7 +5067,7 @@
       "kb_article": "KB4522014",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522014"
     },
     {
       "full_version": "10.0.17763.740",
@@ -5079,7 +5079,7 @@
       "kb_article": "KB4522015",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522015"
     },
     {
       "full_version": "10.0.17763.740",
@@ -5091,7 +5091,7 @@
       "kb_article": "KB4522015",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522015"
     },
     {
       "full_version": "10.0.18362.357",
@@ -5103,7 +5103,7 @@
       "kb_article": "KB4522016",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522016"
     },
     {
       "full_version": "10.0.14393.3242",
@@ -5115,7 +5115,7 @@
       "kb_article": "KB4516061",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516061"
     },
     {
       "full_version": "10.0.14393.3242",
@@ -5127,7 +5127,7 @@
       "kb_article": "KB4516061",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516061"
     },
     {
       "full_version": "10.0.15063.2078",
@@ -5139,7 +5139,7 @@
       "kb_article": "KB4516059",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516059"
     },
     {
       "full_version": "10.0.16299.1420",
@@ -5151,7 +5151,7 @@
       "kb_article": "KB4516071",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516071"
     },
     {
       "full_version": "10.0.17134.1039",
@@ -5163,7 +5163,7 @@
       "kb_article": "KB4516045",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516045"
     },
     {
       "full_version": "10.0.17763.774",
@@ -5175,7 +5175,7 @@
       "kb_article": "KB4516077",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516077"
     },
     {
       "full_version": "10.0.17763.774",
@@ -5187,7 +5187,7 @@
       "kb_article": "KB4516077",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4516077"
     },
     {
       "full_version": "10.0.18362.387",
@@ -5199,7 +5199,7 @@
       "kb_article": "KB4517211",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4517211"
     },
     {
       "full_version": "10.0.14393.3243",
@@ -5211,7 +5211,7 @@
       "kb_article": "KB4524152",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524152"
     },
     {
       "full_version": "10.0.14393.3243",
@@ -5223,7 +5223,7 @@
       "kb_article": "KB4524152",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524152"
     },
     {
       "full_version": "10.0.15063.2079",
@@ -5235,7 +5235,7 @@
       "kb_article": "KB4524151",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524151"
     },
     {
       "full_version": "10.0.16299.1421",
@@ -5247,7 +5247,7 @@
       "kb_article": "KB4524150",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524150"
     },
     {
       "full_version": "10.0.17134.1040",
@@ -5259,7 +5259,7 @@
       "kb_article": "KB4524149",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524149"
     },
     {
       "full_version": "10.0.17763.775",
@@ -5271,7 +5271,7 @@
       "kb_article": "KB4524148",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524148"
     },
     {
       "full_version": "10.0.17763.775",
@@ -5283,7 +5283,7 @@
       "kb_article": "KB4524148",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524148"
     },
     {
       "full_version": "10.0.18362.388",
@@ -5295,7 +5295,7 @@
       "kb_article": "KB4524147",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524147"
     },
     {
       "full_version": "10.0.14393.3274",
@@ -5307,7 +5307,7 @@
       "kb_article": "KB4519998",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519998"
     },
     {
       "full_version": "10.0.14393.3274",
@@ -5319,7 +5319,7 @@
       "kb_article": "KB4519998",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519998"
     },
     {
       "full_version": "10.0.15063.2108",
@@ -5331,7 +5331,7 @@
       "kb_article": "KB4520010",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520010"
     },
     {
       "full_version": "10.0.16299.1451",
@@ -5343,7 +5343,7 @@
       "kb_article": "KB4520004",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520004"
     },
     {
       "full_version": "10.0.17134.1069",
@@ -5355,7 +5355,7 @@
       "kb_article": "KB4520008",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520008"
     },
     {
       "full_version": "10.0.17763.805",
@@ -5367,7 +5367,7 @@
       "kb_article": "KB4519338",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519338"
     },
     {
       "full_version": "10.0.17763.805",
@@ -5379,7 +5379,7 @@
       "kb_article": "KB4519338",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519338"
     },
     {
       "full_version": "10.0.18362.418",
@@ -5391,7 +5391,7 @@
       "kb_article": "KB4517389",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4517389"
     },
     {
       "full_version": "10.0.14393.3300",
@@ -5403,7 +5403,7 @@
       "kb_article": "KB4519979",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519979"
     },
     {
       "full_version": "10.0.14393.3300",
@@ -5415,7 +5415,7 @@
       "kb_article": "KB4519979",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519979"
     },
     {
       "full_version": "10.0.16299.1481",
@@ -5427,7 +5427,7 @@
       "kb_article": "KB4520006",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520006"
     },
     {
       "full_version": "10.0.17134.1099",
@@ -5439,7 +5439,7 @@
       "kb_article": "KB4519978",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4519978"
     },
     {
       "full_version": "10.0.17763.832",
@@ -5451,7 +5451,7 @@
       "kb_article": "KB4520062",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520062"
     },
     {
       "full_version": "10.0.17763.832",
@@ -5463,7 +5463,7 @@
       "kb_article": "KB4520062",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4520062"
     },
     {
       "full_version": "10.0.18362.449",
@@ -5475,7 +5475,7 @@
       "kb_article": "KB4522355",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4522355"
     },
     {
       "full_version": "10.0.14393.3326",
@@ -5487,7 +5487,7 @@
       "kb_article": "KB4525236",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4525236"
     },
     {
       "full_version": "10.0.14393.3326",
@@ -5499,7 +5499,7 @@
       "kb_article": "KB4525236",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4525236"
     },
     {
       "full_version": "10.0.15063.2172",
@@ -5511,7 +5511,7 @@
       "kb_article": "KB4525245",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4525245"
     },
     {
       "full_version": "10.0.16299.1508",
@@ -5523,7 +5523,7 @@
       "kb_article": "KB4525241",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4525241"
     },
     {
       "full_version": "10.0.17134.1130",
@@ -5535,7 +5535,7 @@
       "kb_article": "KB4525237",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4525237"
     },
     {
       "full_version": "10.0.17763.864",
@@ -5547,7 +5547,7 @@
       "kb_article": "KB4523205",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4523205"
     },
     {
       "full_version": "10.0.17763.864",
@@ -5559,7 +5559,7 @@
       "kb_article": "KB4523205",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4523205"
     },
     {
       "full_version": "10.0.18362.476",
@@ -5571,7 +5571,7 @@
       "kb_article": "KB4524570",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524570"
     },
     {
       "full_version": "10.0.18363.476",
@@ -5583,7 +5583,7 @@
       "kb_article": "KB4524570",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4524570"
     },
     {
       "full_version": "10.0.14393.3384",
@@ -5595,7 +5595,7 @@
       "kb_article": "KB4530689",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530689"
     },
     {
       "full_version": "10.0.14393.3384",
@@ -5607,7 +5607,7 @@
       "kb_article": "KB4530689",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530689"
     },
     {
       "full_version": "10.0.15063.2224",
@@ -5619,7 +5619,7 @@
       "kb_article": "KB4530711",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530711"
     },
     {
       "full_version": "10.0.16299.1565",
@@ -5631,7 +5631,7 @@
       "kb_article": "KB4530714",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530714"
     },
     {
       "full_version": "10.0.17134.1184",
@@ -5643,7 +5643,7 @@
       "kb_article": "KB4530717",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530717"
     },
     {
       "full_version": "10.0.17763.914",
@@ -5655,7 +5655,7 @@
       "kb_article": "KB4530715",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530715"
     },
     {
       "full_version": "10.0.17763.914",
@@ -5667,7 +5667,7 @@
       "kb_article": "KB4530715",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530715"
     },
     {
       "full_version": "10.0.18362.535",
@@ -5679,7 +5679,7 @@
       "kb_article": "KB4530684",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530684"
     },
     {
       "full_version": "10.0.18363.535",
@@ -5691,7 +5691,7 @@
       "kb_article": "KB4530684",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4530684"
     },
     {
       "full_version": "10.0.14393.3443",
@@ -5703,7 +5703,7 @@
       "kb_article": "KB4534271",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534271"
     },
     {
       "full_version": "10.0.14393.3443",
@@ -5715,7 +5715,7 @@
       "kb_article": "KB4534271",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534271"
     },
     {
       "full_version": "10.0.15063.2254",
@@ -5727,7 +5727,7 @@
       "kb_article": "KB4534296",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534296"
     },
     {
       "full_version": "10.0.16299.1625",
@@ -5739,7 +5739,7 @@
       "kb_article": "KB4534276",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534276"
     },
     {
       "full_version": "10.0.17134.1246",
@@ -5751,7 +5751,7 @@
       "kb_article": "KB4534293",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534293"
     },
     {
       "full_version": "10.0.17763.973",
@@ -5763,7 +5763,7 @@
       "kb_article": "KB4534273",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534273"
     },
     {
       "full_version": "10.0.17763.973",
@@ -5775,7 +5775,7 @@
       "kb_article": "KB4534273",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534273"
     },
     {
       "full_version": "10.0.18362.592",
@@ -5787,7 +5787,7 @@
       "kb_article": "KB4528760",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4528760"
     },
     {
       "full_version": "10.0.18363.592",
@@ -5799,7 +5799,7 @@
       "kb_article": "KB4528760",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4528760"
     },
     {
       "full_version": "10.0.14393.3474",
@@ -5811,7 +5811,7 @@
       "kb_article": "KB4534307",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534307"
     },
     {
       "full_version": "10.0.14393.3474",
@@ -5823,7 +5823,7 @@
       "kb_article": "KB4534307",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534307"
     },
     {
       "full_version": "10.0.16299.1654",
@@ -5835,7 +5835,7 @@
       "kb_article": "KB4534318",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534318"
     },
     {
       "full_version": "10.0.17134.1276",
@@ -5847,7 +5847,7 @@
       "kb_article": "KB4534308",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534308"
     },
     {
       "full_version": "10.0.17763.1012",
@@ -5859,7 +5859,7 @@
       "kb_article": "KB4534321",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534321"
     },
     {
       "full_version": "10.0.17763.1012",
@@ -5871,7 +5871,7 @@
       "kb_article": "KB4534321",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4534321"
     },
     {
       "full_version": "10.0.18362.628",
@@ -5883,7 +5883,7 @@
       "kb_article": "KB4532695",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532695"
     },
     {
       "full_version": "10.0.18363.628",
@@ -5895,7 +5895,7 @@
       "kb_article": "KB4532695",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532695"
     },
     {
       "full_version": "10.0.14393.3504",
@@ -5907,7 +5907,7 @@
       "kb_article": "KB4537764",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537764"
     },
     {
       "full_version": "10.0.14393.3504",
@@ -5919,7 +5919,7 @@
       "kb_article": "KB4537764",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537764"
     },
     {
       "full_version": "10.0.15063.2284",
@@ -5931,7 +5931,7 @@
       "kb_article": "KB4537765",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537765"
     },
     {
       "full_version": "10.0.16299.1686",
@@ -5943,7 +5943,7 @@
       "kb_article": "KB4537789",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537789"
     },
     {
       "full_version": "10.0.17134.1304",
@@ -5955,7 +5955,7 @@
       "kb_article": "KB4537762",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537762"
     },
     {
       "full_version": "10.0.17763.1039",
@@ -5967,7 +5967,7 @@
       "kb_article": "KB4532691",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532691"
     },
     {
       "full_version": "10.0.17763.1039",
@@ -5979,7 +5979,7 @@
       "kb_article": "KB4532691",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532691"
     },
     {
       "full_version": "10.0.18362.657",
@@ -5991,7 +5991,7 @@
       "kb_article": "KB4532693",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532693"
     },
     {
       "full_version": "10.0.18363.657",
@@ -6003,7 +6003,7 @@
       "kb_article": "KB4532693",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4532693"
     },
     {
       "full_version": "10.0.14393.3542",
@@ -6015,7 +6015,7 @@
       "kb_article": "KB4537806",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537806"
     },
     {
       "full_version": "10.0.14393.3542",
@@ -6027,7 +6027,7 @@
       "kb_article": "KB4537806",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537806"
     },
     {
       "full_version": "10.0.16299.1717",
@@ -6039,7 +6039,7 @@
       "kb_article": "KB4537816",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537816"
     },
     {
       "full_version": "10.0.17134.1345",
@@ -6051,7 +6051,7 @@
       "kb_article": "KB4537795",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537795"
     },
     {
       "full_version": "10.0.17763.1075",
@@ -6063,7 +6063,7 @@
       "kb_article": "KB4537818",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537818"
     },
     {
       "full_version": "10.0.17763.1075",
@@ -6075,7 +6075,7 @@
       "kb_article": "KB4537818",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4537818"
     },
     {
       "full_version": "10.0.18362.693",
@@ -6087,7 +6087,7 @@
       "kb_article": "KB4535996",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4535996"
     },
     {
       "full_version": "10.0.18363.693",
@@ -6099,7 +6099,7 @@
       "kb_article": "KB4535996",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4535996"
     },
     {
       "full_version": "10.0.14393.3564",
@@ -6111,7 +6111,7 @@
       "kb_article": "KB4540670",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540670"
     },
     {
       "full_version": "10.0.14393.3564",
@@ -6123,7 +6123,7 @@
       "kb_article": "KB4540670",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540670"
     },
     {
       "full_version": "10.0.15063.2313",
@@ -6135,7 +6135,7 @@
       "kb_article": "KB4540705",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540705"
     },
     {
       "full_version": "10.0.16299.1747",
@@ -6147,7 +6147,7 @@
       "kb_article": "KB4540681",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540681"
     },
     {
       "full_version": "10.0.17134.1365",
@@ -6159,7 +6159,7 @@
       "kb_article": "KB4540689",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540689"
     },
     {
       "full_version": "10.0.17763.1098",
@@ -6171,7 +6171,7 @@
       "kb_article": "KB4538461",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4538461"
     },
     {
       "full_version": "10.0.17763.1098",
@@ -6183,7 +6183,7 @@
       "kb_article": "KB4538461",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4538461"
     },
     {
       "full_version": "10.0.18362.719",
@@ -6195,7 +6195,7 @@
       "kb_article": "KB4540673",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540673"
     },
     {
       "full_version": "10.0.18363.719",
@@ -6207,7 +6207,7 @@
       "kb_article": "KB4540673",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4540673"
     },
     {
       "full_version": "10.0.18362.720",
@@ -6219,7 +6219,7 @@
       "kb_article": "KB4551762",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4551762"
     },
     {
       "full_version": "10.0.18363.720",
@@ -6231,7 +6231,7 @@
       "kb_article": "KB4551762",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4551762"
     },
     {
       "full_version": "10.0.14393.3595",
@@ -6243,7 +6243,7 @@
       "kb_article": "KB4541329",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541329"
     },
     {
       "full_version": "10.0.14393.3595",
@@ -6255,7 +6255,7 @@
       "kb_article": "KB4541329",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541329"
     },
     {
       "full_version": "10.0.16299.1775",
@@ -6267,7 +6267,7 @@
       "kb_article": "KB4541330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541330"
     },
     {
       "full_version": "10.0.17134.1399",
@@ -6279,7 +6279,7 @@
       "kb_article": "KB4541333",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541333"
     },
     {
       "full_version": "10.0.17763.1131",
@@ -6291,7 +6291,7 @@
       "kb_article": "KB4541331",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541331"
     },
     {
       "full_version": "10.0.17763.1131",
@@ -6303,7 +6303,7 @@
       "kb_article": "KB4541331",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541331"
     },
     {
       "full_version": "10.0.18362.752",
@@ -6315,7 +6315,7 @@
       "kb_article": "KB4541335",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541335"
     },
     {
       "full_version": "10.0.18363.752",
@@ -6327,7 +6327,7 @@
       "kb_article": "KB4541335",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4541335"
     },
     {
       "full_version": "10.0.16299.1776",
@@ -6339,7 +6339,7 @@
       "kb_article": "KB4554342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554342"
     },
     {
       "full_version": "10.0.17134.1401",
@@ -6351,7 +6351,7 @@
       "kb_article": "KB4554349",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554349"
     },
     {
       "full_version": "10.0.17763.1132",
@@ -6363,7 +6363,7 @@
       "kb_article": "KB4554354",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554354"
     },
     {
       "full_version": "10.0.17763.1132",
@@ -6375,7 +6375,7 @@
       "kb_article": "KB4554354",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554354"
     },
     {
       "full_version": "10.0.18362.753",
@@ -6387,7 +6387,7 @@
       "kb_article": "KB4554364",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554364"
     },
     {
       "full_version": "10.0.18363.753",
@@ -6399,7 +6399,7 @@
       "kb_article": "KB4554364",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4554364"
     },
     {
       "full_version": "10.0.14393.3630",
@@ -6411,7 +6411,7 @@
       "kb_article": "KB4550929",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550929"
     },
     {
       "full_version": "10.0.14393.3630",
@@ -6423,7 +6423,7 @@
       "kb_article": "KB4550929",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550929"
     },
     {
       "full_version": "10.0.15063.2346",
@@ -6435,7 +6435,7 @@
       "kb_article": "KB4550939",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550939"
     },
     {
       "full_version": "10.0.16299.1806",
@@ -6447,7 +6447,7 @@
       "kb_article": "KB4550927",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550927"
     },
     {
       "full_version": "10.0.17134.1425",
@@ -6459,7 +6459,7 @@
       "kb_article": "KB4550922",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550922"
     },
     {
       "full_version": "10.0.17763.1158",
@@ -6471,7 +6471,7 @@
       "kb_article": "KB4549949",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4549949"
     },
     {
       "full_version": "10.0.17763.1158",
@@ -6483,7 +6483,7 @@
       "kb_article": "KB4549949",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4549949"
     },
     {
       "full_version": "10.0.18362.778",
@@ -6495,7 +6495,7 @@
       "kb_article": "KB4549951",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4549951"
     },
     {
       "full_version": "10.0.18363.778",
@@ -6507,7 +6507,7 @@
       "kb_article": "KB4549951",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4549951"
     },
     {
       "full_version": "10.0.14393.3659",
@@ -6519,7 +6519,7 @@
       "kb_article": "KB4550947",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550947"
     },
     {
       "full_version": "10.0.14393.3659",
@@ -6531,7 +6531,7 @@
       "kb_article": "KB4550947",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550947"
     },
     {
       "full_version": "10.0.17134.1456",
@@ -6543,7 +6543,7 @@
       "kb_article": "KB4550944",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550944"
     },
     {
       "full_version": "10.0.17763.1192",
@@ -6555,7 +6555,7 @@
       "kb_article": "KB4550969",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550969"
     },
     {
       "full_version": "10.0.17763.1192",
@@ -6567,7 +6567,7 @@
       "kb_article": "KB4550969",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550969"
     },
     {
       "full_version": "10.0.18362.815",
@@ -6579,7 +6579,7 @@
       "kb_article": "KB4550945",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550945"
     },
     {
       "full_version": "10.0.18363.815",
@@ -6591,7 +6591,7 @@
       "kb_article": "KB4550945",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4550945"
     },
     {
       "full_version": "10.0.14393.3686",
@@ -6603,7 +6603,7 @@
       "kb_article": "KB4556813",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556813"
     },
     {
       "full_version": "10.0.14393.3686",
@@ -6615,7 +6615,7 @@
       "kb_article": "KB4556813",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556813"
     },
     {
       "full_version": "10.0.15063.2375",
@@ -6627,7 +6627,7 @@
       "kb_article": "KB4556804",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556804"
     },
     {
       "full_version": "10.0.16299.1868",
@@ -6639,7 +6639,7 @@
       "kb_article": "KB4556812",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556812"
     },
     {
       "full_version": "10.0.17134.1488",
@@ -6651,7 +6651,7 @@
       "kb_article": "KB4556807",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556807"
     },
     {
       "full_version": "10.0.17763.1217",
@@ -6663,7 +6663,7 @@
       "kb_article": "KB4551853",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4551853"
     },
     {
       "full_version": "10.0.17763.1217",
@@ -6675,7 +6675,7 @@
       "kb_article": "KB4551853",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4551853"
     },
     {
       "full_version": "10.0.18362.836",
@@ -6687,7 +6687,7 @@
       "kb_article": "KB4556799",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556799"
     },
     {
       "full_version": "10.0.18363.836",
@@ -6699,7 +6699,7 @@
       "kb_article": "KB4556799",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4556799"
     },
     {
       "full_version": "10.0.14393.3750",
@@ -6711,7 +6711,7 @@
       "kb_article": "KB4561616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561616"
     },
     {
       "full_version": "10.0.14393.3750",
@@ -6723,7 +6723,7 @@
       "kb_article": "KB4561616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561616"
     },
     {
       "full_version": "10.0.15063.2409",
@@ -6735,7 +6735,7 @@
       "kb_article": "KB4561605",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561605"
     },
     {
       "full_version": "10.0.16299.1932",
@@ -6747,7 +6747,7 @@
       "kb_article": "KB4561602",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561602"
     },
     {
       "full_version": "10.0.17134.1550",
@@ -6759,7 +6759,7 @@
       "kb_article": "KB4561621",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561621"
     },
     {
       "full_version": "10.0.17763.1282",
@@ -6771,7 +6771,7 @@
       "kb_article": "KB4561608",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561608"
     },
     {
       "full_version": "10.0.17763.1282",
@@ -6783,7 +6783,7 @@
       "kb_article": "KB4561608",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4561608"
     },
     {
       "full_version": "10.0.18362.900",
@@ -6795,7 +6795,7 @@
       "kb_article": "KB4560960",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4560960"
     },
     {
       "full_version": "10.0.18363.900",
@@ -6807,7 +6807,7 @@
       "kb_article": "KB4560960",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4560960"
     },
     {
       "full_version": "10.0.19041.329",
@@ -6819,7 +6819,7 @@
       "kb_article": "KB4557957",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4557957"
     },
     {
       "full_version": "10.0.17134.1553",
@@ -6831,7 +6831,7 @@
       "kb_article": "KB4567514",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567514"
     },
     {
       "full_version": "10.0.17763.1294",
@@ -6843,7 +6843,7 @@
       "kb_article": "KB4567513",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567513"
     },
     {
       "full_version": "10.0.17763.1294",
@@ -6855,7 +6855,7 @@
       "kb_article": "KB4567513",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567513"
     },
     {
       "full_version": "10.0.18362.904",
@@ -6867,7 +6867,7 @@
       "kb_article": "KB4567512",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567512"
     },
     {
       "full_version": "10.0.18363.904",
@@ -6879,7 +6879,7 @@
       "kb_article": "KB4567512",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567512"
     },
     {
       "full_version": "10.0.14393.3755",
@@ -6891,7 +6891,7 @@
       "kb_article": "KB4567517",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567517"
     },
     {
       "full_version": "10.0.14393.3755",
@@ -6903,7 +6903,7 @@
       "kb_article": "KB4567517",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567517"
     },
     {
       "full_version": "10.0.15063.2411",
@@ -6915,7 +6915,7 @@
       "kb_article": "KB4567516",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567516"
     },
     {
       "full_version": "10.0.16299.1937",
@@ -6927,7 +6927,7 @@
       "kb_article": "KB4567515",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567515"
     },
     {
       "full_version": "10.0.19041.331",
@@ -6939,7 +6939,7 @@
       "kb_article": "KB4567523",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4567523"
     },
     {
       "full_version": "10.0.14393.3808",
@@ -6951,7 +6951,7 @@
       "kb_article": "KB4565511",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565511"
     },
     {
       "full_version": "10.0.14393.3808",
@@ -6963,7 +6963,7 @@
       "kb_article": "KB4565511",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565511"
     },
     {
       "full_version": "10.0.15063.2439",
@@ -6975,7 +6975,7 @@
       "kb_article": "KB4565499",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565499"
     },
     {
       "full_version": "10.0.16299.1992",
@@ -6987,7 +6987,7 @@
       "kb_article": "KB4565508",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565508"
     },
     {
       "full_version": "10.0.17134.1610",
@@ -6999,7 +6999,7 @@
       "kb_article": "KB4565489",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565489"
     },
     {
       "full_version": "10.0.17763.1339",
@@ -7011,7 +7011,7 @@
       "kb_article": "KB4558998",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4558998"
     },
     {
       "full_version": "10.0.17763.1339",
@@ -7023,7 +7023,7 @@
       "kb_article": "KB4558998",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4558998"
     },
     {
       "full_version": "10.0.18362.959",
@@ -7035,7 +7035,7 @@
       "kb_article": "KB4565483",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565483"
     },
     {
       "full_version": "10.0.18363.959",
@@ -7047,7 +7047,7 @@
       "kb_article": "KB4565483",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565483"
     },
     {
       "full_version": "10.0.19041.388",
@@ -7059,7 +7059,7 @@
       "kb_article": "KB4565503",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565503"
     },
     {
       "full_version": "10.0.17763.1369",
@@ -7071,7 +7071,7 @@
       "kb_article": "KB4559003",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4559003"
     },
     {
       "full_version": "10.0.17763.1369",
@@ -7083,7 +7083,7 @@
       "kb_article": "KB4559003",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4559003"
     },
     {
       "full_version": "10.0.18362.997",
@@ -7095,7 +7095,7 @@
       "kb_article": "KB4559004",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4559004"
     },
     {
       "full_version": "10.0.18363.997",
@@ -7107,7 +7107,7 @@
       "kb_article": "KB4559004",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4559004"
     },
     {
       "full_version": "10.0.19041.423",
@@ -7119,7 +7119,7 @@
       "kb_article": "KB4568831",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4568831"
     },
     {
       "full_version": "10.0.14393.3866",
@@ -7131,7 +7131,7 @@
       "kb_article": "KB4571694",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571694"
     },
     {
       "full_version": "10.0.14393.3866",
@@ -7143,7 +7143,7 @@
       "kb_article": "KB4571694",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571694"
     },
     {
       "full_version": "10.0.15063.2467",
@@ -7155,7 +7155,7 @@
       "kb_article": "KB4571689",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571689"
     },
     {
       "full_version": "10.0.16299.2045",
@@ -7167,7 +7167,7 @@
       "kb_article": "KB4571741",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571741"
     },
     {
       "full_version": "10.0.17134.1667",
@@ -7179,7 +7179,7 @@
       "kb_article": "KB4571709",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571709"
     },
     {
       "full_version": "10.0.17763.1397",
@@ -7191,7 +7191,7 @@
       "kb_article": "KB4565349",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565349"
     },
     {
       "full_version": "10.0.17763.1397",
@@ -7203,7 +7203,7 @@
       "kb_article": "KB4565349",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565349"
     },
     {
       "full_version": "10.0.18362.1016",
@@ -7215,7 +7215,7 @@
       "kb_article": "KB4565351",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565351"
     },
     {
       "full_version": "10.0.18363.1016",
@@ -7227,7 +7227,7 @@
       "kb_article": "KB4565351",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4565351"
     },
     {
       "full_version": "10.0.19041.450",
@@ -7239,7 +7239,7 @@
       "kb_article": "KB4566782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4566782"
     },
     {
       "full_version": "10.0.17763.1432",
@@ -7251,7 +7251,7 @@
       "kb_article": "KB4571748",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571748"
     },
     {
       "full_version": "10.0.17763.1432",
@@ -7263,7 +7263,7 @@
       "kb_article": "KB4571748",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571748"
     },
     {
       "full_version": "10.0.18362.1049",
@@ -7275,7 +7275,7 @@
       "kb_article": "KB4566116",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4566116"
     },
     {
       "full_version": "10.0.18363.1049",
@@ -7287,7 +7287,7 @@
       "kb_article": "KB4566116",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4566116"
     },
     {
       "full_version": "10.0.19041.488",
@@ -7299,7 +7299,7 @@
       "kb_article": "KB4571744",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571744"
     },
     {
       "full_version": "10.0.14393.3930",
@@ -7311,7 +7311,7 @@
       "kb_article": "KB4577015",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577015"
     },
     {
       "full_version": "10.0.14393.3930",
@@ -7323,7 +7323,7 @@
       "kb_article": "KB4577015",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577015"
     },
     {
       "full_version": "10.0.15063.2500",
@@ -7335,7 +7335,7 @@
       "kb_article": "KB4577021",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577021"
     },
     {
       "full_version": "10.0.16299.2107",
@@ -7347,7 +7347,7 @@
       "kb_article": "KB4577041",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577041"
     },
     {
       "full_version": "10.0.17134.1726",
@@ -7359,7 +7359,7 @@
       "kb_article": "KB4577032",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577032"
     },
     {
       "full_version": "10.0.17763.1457",
@@ -7371,7 +7371,7 @@
       "kb_article": "KB4570333",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4570333"
     },
     {
       "full_version": "10.0.17763.1457",
@@ -7383,7 +7383,7 @@
       "kb_article": "KB4570333",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4570333"
     },
     {
       "full_version": "10.0.18362.1082",
@@ -7395,7 +7395,7 @@
       "kb_article": "KB4574727",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4574727"
     },
     {
       "full_version": "10.0.18363.1082",
@@ -7407,7 +7407,7 @@
       "kb_article": "KB4574727",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4574727"
     },
     {
       "full_version": "10.0.19041.508",
@@ -7419,7 +7419,7 @@
       "kb_article": "KB4571756",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4571756"
     },
     {
       "full_version": "10.0.17763.1490",
@@ -7431,7 +7431,7 @@
       "kb_article": "KB4577069",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577069"
     },
     {
       "full_version": "10.0.17763.1490",
@@ -7443,7 +7443,7 @@
       "kb_article": "KB4577069",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577069"
     },
     {
       "full_version": "10.0.18362.1110",
@@ -7455,7 +7455,7 @@
       "kb_article": "KB4577062",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577062"
     },
     {
       "full_version": "10.0.18363.1110",
@@ -7467,7 +7467,7 @@
       "kb_article": "KB4577062",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577062"
     },
     {
       "full_version": "10.0.19041.546",
@@ -7479,7 +7479,7 @@
       "kb_article": "KB4577063",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577063"
     },
     {
       "full_version": "10.0.14393.3986",
@@ -7491,7 +7491,7 @@
       "kb_article": "KB4580346",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580346"
     },
     {
       "full_version": "10.0.14393.3986",
@@ -7503,7 +7503,7 @@
       "kb_article": "KB4580346",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580346"
     },
     {
       "full_version": "10.0.15063.2525",
@@ -7515,7 +7515,7 @@
       "kb_article": "KB4580370",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580370"
     },
     {
       "full_version": "10.0.16299.2166",
@@ -7527,7 +7527,7 @@
       "kb_article": "KB4580328",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580328"
     },
     {
       "full_version": "10.0.17134.1792",
@@ -7539,7 +7539,7 @@
       "kb_article": "KB4580330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580330"
     },
     {
       "full_version": "10.0.17763.1518",
@@ -7551,7 +7551,7 @@
       "kb_article": "KB4577668",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577668"
     },
     {
       "full_version": "10.0.17763.1518",
@@ -7563,7 +7563,7 @@
       "kb_article": "KB4577668",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577668"
     },
     {
       "full_version": "10.0.18362.1139",
@@ -7575,7 +7575,7 @@
       "kb_article": "KB4577671",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577671"
     },
     {
       "full_version": "10.0.18363.1139",
@@ -7587,7 +7587,7 @@
       "kb_article": "KB4577671",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4577671"
     },
     {
       "full_version": "10.0.19041.572",
@@ -7599,7 +7599,7 @@
       "kb_article": "KB4579311",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4579311"
     },
     {
       "full_version": "10.0.17763.1554",
@@ -7611,7 +7611,7 @@
       "kb_article": "KB4580390",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580390"
     },
     {
       "full_version": "10.0.17763.1554",
@@ -7623,7 +7623,7 @@
       "kb_article": "KB4580390",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580390"
     },
     {
       "full_version": "10.0.18362.1171",
@@ -7635,7 +7635,7 @@
       "kb_article": "KB4580386",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580386"
     },
     {
       "full_version": "10.0.18363.1171",
@@ -7647,7 +7647,7 @@
       "kb_article": "KB4580386",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580386"
     },
     {
       "full_version": "10.0.19041.610",
@@ -7659,7 +7659,7 @@
       "kb_article": "KB4580364",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580364"
     },
     {
       "full_version": "10.0.19042.610",
@@ -7671,7 +7671,7 @@
       "kb_article": "KB4580364",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4580364"
     },
     {
       "full_version": "10.0.14393.4046",
@@ -7683,7 +7683,7 @@
       "kb_article": "KB4586830",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586830"
     },
     {
       "full_version": "10.0.14393.4046",
@@ -7695,7 +7695,7 @@
       "kb_article": "KB4586830",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586830"
     },
     {
       "full_version": "10.0.15063.2554",
@@ -7707,7 +7707,7 @@
       "kb_article": "KB4586782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586782"
     },
     {
       "full_version": "10.0.17134.1845",
@@ -7719,7 +7719,7 @@
       "kb_article": "KB4586785",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586785"
     },
     {
       "full_version": "10.0.17763.1577",
@@ -7731,7 +7731,7 @@
       "kb_article": "KB4586793",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586793"
     },
     {
       "full_version": "10.0.17763.1577",
@@ -7743,7 +7743,7 @@
       "kb_article": "KB4586793",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586793"
     },
     {
       "full_version": "10.0.18362.1198",
@@ -7755,7 +7755,7 @@
       "kb_article": "KB4586786",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586786"
     },
     {
       "full_version": "10.0.18363.1198",
@@ -7767,7 +7767,7 @@
       "kb_article": "KB4586786",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586786"
     },
     {
       "full_version": "10.0.19041.630",
@@ -7779,7 +7779,7 @@
       "kb_article": "KB4586781",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586781"
     },
     {
       "full_version": "10.0.19042.630",
@@ -7791,7 +7791,7 @@
       "kb_article": "KB4586781",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586781"
     },
     {
       "full_version": "10.0.17763.1579",
@@ -7803,7 +7803,7 @@
       "kb_article": "KB4594442",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594442"
     },
     {
       "full_version": "10.0.17763.1579",
@@ -7815,7 +7815,7 @@
       "kb_article": "KB4594442",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594442"
     },
     {
       "full_version": "10.0.14393.4048",
@@ -7827,7 +7827,7 @@
       "kb_article": "KB4594441",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594441"
     },
     {
       "full_version": "10.0.14393.4048",
@@ -7839,7 +7839,7 @@
       "kb_article": "KB4594441",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594441"
     },
     {
       "full_version": "10.0.17763.1613",
@@ -7851,7 +7851,7 @@
       "kb_article": "KB4586839",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586839"
     },
     {
       "full_version": "10.0.17763.1613",
@@ -7863,7 +7863,7 @@
       "kb_article": "KB4586839",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586839"
     },
     {
       "full_version": "10.0.18362.1199",
@@ -7875,7 +7875,7 @@
       "kb_article": "KB4594443",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594443"
     },
     {
       "full_version": "10.0.18362.1237",
@@ -7887,7 +7887,7 @@
       "kb_article": "KB4586819",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586819"
     },
     {
       "full_version": "10.0.18363.1199",
@@ -7899,7 +7899,7 @@
       "kb_article": "KB4594443",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594443"
     },
     {
       "full_version": "10.0.18363.1237",
@@ -7911,7 +7911,7 @@
       "kb_article": "KB4586819",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586819"
     },
     {
       "full_version": "10.0.19041.631",
@@ -7923,7 +7923,7 @@
       "kb_article": "KB4594440",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594440"
     },
     {
       "full_version": "10.0.19042.631",
@@ -7935,7 +7935,7 @@
       "kb_article": "KB4594440",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4594440"
     },
     {
       "full_version": "10.0.19041.662",
@@ -7947,7 +7947,7 @@
       "kb_article": "KB4586853",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586853"
     },
     {
       "full_version": "10.0.19042.662",
@@ -7959,7 +7959,7 @@
       "kb_article": "KB4586853",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4586853"
     },
     {
       "full_version": "10.0.14393.4104",
@@ -7971,7 +7971,7 @@
       "kb_article": "KB4593226",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4593226"
     },
     {
       "full_version": "10.0.14393.4104",
@@ -7983,7 +7983,7 @@
       "kb_article": "KB4593226",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4593226"
     },
     {
       "full_version": "10.0.15063.2584",
@@ -7995,7 +7995,7 @@
       "kb_article": "KB4592473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592473"
     },
     {
       "full_version": "10.0.17134.1902",
@@ -8007,7 +8007,7 @@
       "kb_article": "KB4592446",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592446"
     },
     {
       "full_version": "10.0.17763.1637",
@@ -8019,7 +8019,7 @@
       "kb_article": "KB4592440",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592440"
     },
     {
       "full_version": "10.0.17763.1637",
@@ -8031,7 +8031,7 @@
       "kb_article": "KB4592440",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592440"
     },
     {
       "full_version": "10.0.18362.1256",
@@ -8043,7 +8043,7 @@
       "kb_article": "KB4592449",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592449"
     },
     {
       "full_version": "10.0.18363.1256",
@@ -8055,7 +8055,7 @@
       "kb_article": "KB4592449",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592449"
     },
     {
       "full_version": "10.0.19041.685",
@@ -8067,7 +8067,7 @@
       "kb_article": "KB4592438",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592438"
     },
     {
       "full_version": "10.0.19042.685",
@@ -8079,7 +8079,7 @@
       "kb_article": "KB4592438",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4592438"
     },
     {
       "full_version": "10.0.14393.4169",
@@ -8091,7 +8091,7 @@
       "kb_article": "KB4598243",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598243"
     },
     {
       "full_version": "10.0.14393.4169",
@@ -8103,7 +8103,7 @@
       "kb_article": "KB4598243",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598243"
     },
     {
       "full_version": "10.0.15063.2614",
@@ -8115,7 +8115,7 @@
       "kb_article": "KB4599208",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4599208"
     },
     {
       "full_version": "10.0.17134.1967",
@@ -8127,7 +8127,7 @@
       "kb_article": "KB4598245",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598245"
     },
     {
       "full_version": "10.0.17763.1697",
@@ -8139,7 +8139,7 @@
       "kb_article": "KB4598230",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598230"
     },
     {
       "full_version": "10.0.17763.1697",
@@ -8151,7 +8151,7 @@
       "kb_article": "KB4598230",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598230"
     },
     {
       "full_version": "10.0.18363.1316",
@@ -8163,7 +8163,7 @@
       "kb_article": "KB4598229",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598229"
     },
     {
       "full_version": "10.0.19041.746",
@@ -8175,7 +8175,7 @@
       "kb_article": "KB4598242",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598242"
     },
     {
       "full_version": "10.0.19042.746",
@@ -8187,7 +8187,7 @@
       "kb_article": "KB4598242",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598242"
     },
     {
       "full_version": "10.0.17763.1728",
@@ -8199,7 +8199,7 @@
       "kb_article": "KB4598296",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598296"
     },
     {
       "full_version": "10.0.17763.1728",
@@ -8211,7 +8211,7 @@
       "kb_article": "KB4598296",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598296"
     },
     {
       "full_version": "10.0.18363.1350",
@@ -8223,7 +8223,7 @@
       "kb_article": "KB4598298",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598298"
     },
     {
       "full_version": "10.0.19041.789",
@@ -8235,7 +8235,7 @@
       "kb_article": "KB4598291",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598291"
     },
     {
       "full_version": "10.0.19042.789",
@@ -8247,7 +8247,7 @@
       "kb_article": "KB4598291",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4598291"
     },
     {
       "full_version": "10.0.14393.4225",
@@ -8259,7 +8259,7 @@
       "kb_article": "KB4601318",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601318"
     },
     {
       "full_version": "10.0.14393.4225",
@@ -8271,7 +8271,7 @@
       "kb_article": "KB4601318",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601318"
     },
     {
       "full_version": "10.0.15063.2642",
@@ -8283,7 +8283,7 @@
       "kb_article": "KB4601330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601330"
     },
     {
       "full_version": "10.0.18363.1377",
@@ -8295,7 +8295,7 @@
       "kb_article": "KB4601315",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601315"
     },
     {
       "full_version": "10.0.18363.1379",
@@ -8307,7 +8307,7 @@
       "kb_article": "KB5001028",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001028"
     },
     {
       "full_version": "10.0.17763.1790",
@@ -8319,7 +8319,7 @@
       "kb_article": "KB4601383",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601383"
     },
     {
       "full_version": "10.0.17763.1790",
@@ -8331,7 +8331,7 @@
       "kb_article": "KB4601383",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601383"
     },
     {
       "full_version": "10.0.18363.1411",
@@ -8343,7 +8343,7 @@
       "kb_article": "KB4601380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601380"
     },
     {
       "full_version": "10.0.19041.844",
@@ -8355,7 +8355,7 @@
       "kb_article": "KB4601382",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601382"
     },
     {
       "full_version": "10.0.19042.844",
@@ -8367,7 +8367,7 @@
       "kb_article": "KB4601382",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/4601382"
     },
     {
       "full_version": "10.0.14393.4283",
@@ -8379,7 +8379,7 @@
       "kb_article": "KB5000803",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000803"
     },
     {
       "full_version": "10.0.14393.4283",
@@ -8391,7 +8391,7 @@
       "kb_article": "KB5000803",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000803"
     },
     {
       "full_version": "10.0.15063.2679",
@@ -8403,7 +8403,7 @@
       "kb_article": "KB5000812",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000812"
     },
     {
       "full_version": "10.0.17134.2087",
@@ -8415,7 +8415,7 @@
       "kb_article": "KB5000809",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000809"
     },
     {
       "full_version": "10.0.17763.1817",
@@ -8427,7 +8427,7 @@
       "kb_article": "KB5000822",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000822"
     },
     {
       "full_version": "10.0.17763.1817",
@@ -8439,7 +8439,7 @@
       "kb_article": "KB5000822",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000822"
     },
     {
       "full_version": "10.0.18363.1440",
@@ -8451,7 +8451,7 @@
       "kb_article": "KB5000808",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000808"
     },
     {
       "full_version": "10.0.19041.867",
@@ -8463,7 +8463,7 @@
       "kb_article": "KB5000802",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000802"
     },
     {
       "full_version": "10.0.19042.867",
@@ -8475,7 +8475,7 @@
       "kb_article": "KB5000802",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000802"
     },
     {
       "full_version": "10.0.17134.2088",
@@ -8487,7 +8487,7 @@
       "kb_article": "KB5001565",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001565"
     },
     {
       "full_version": "10.0.17763.1821",
@@ -8499,7 +8499,7 @@
       "kb_article": "KB5001568",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001568"
     },
     {
       "full_version": "10.0.17763.1821",
@@ -8511,7 +8511,7 @@
       "kb_article": "KB5001568",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001568"
     },
     {
       "full_version": "10.0.18363.1441",
@@ -8523,7 +8523,7 @@
       "kb_article": "KB5001566",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001566"
     },
     {
       "full_version": "10.0.19041.868",
@@ -8535,7 +8535,7 @@
       "kb_article": "KB5001567",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001567"
     },
     {
       "full_version": "10.0.19042.868",
@@ -8547,7 +8547,7 @@
       "kb_article": "KB5001567",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001567"
     },
     {
       "full_version": "10.0.14393.4288",
@@ -8559,7 +8559,7 @@
       "kb_article": "KB5001633",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001633"
     },
     {
       "full_version": "10.0.14393.4288",
@@ -8571,7 +8571,7 @@
       "kb_article": "KB5001633",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001633"
     },
     {
       "full_version": "10.0.17134.2090",
@@ -8583,7 +8583,7 @@
       "kb_article": "KB5001634",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001634"
     },
     {
       "full_version": "10.0.17763.1823",
@@ -8595,7 +8595,7 @@
       "kb_article": "KB5001638",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001638"
     },
     {
       "full_version": "10.0.17763.1823",
@@ -8607,7 +8607,7 @@
       "kb_article": "KB5001638",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001638"
     },
     {
       "full_version": "10.0.18363.1443",
@@ -8619,7 +8619,7 @@
       "kb_article": "KB5001648",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001648"
     },
     {
       "full_version": "10.0.19041.870",
@@ -8631,7 +8631,7 @@
       "kb_article": "KB5001649",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001649"
     },
     {
       "full_version": "10.0.19042.870",
@@ -8643,7 +8643,7 @@
       "kb_article": "KB5001649",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001649"
     },
     {
       "full_version": "10.0.17763.1852",
@@ -8655,7 +8655,7 @@
       "kb_article": "KB5000854",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000854"
     },
     {
       "full_version": "10.0.17763.1852",
@@ -8667,7 +8667,7 @@
       "kb_article": "KB5000854",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000854"
     },
     {
       "full_version": "10.0.18363.1474",
@@ -8679,7 +8679,7 @@
       "kb_article": "KB5000850",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000850"
     },
     {
       "full_version": "10.0.19041.906",
@@ -8691,7 +8691,7 @@
       "kb_article": "KB5000842",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000842"
     },
     {
       "full_version": "10.0.19042.906",
@@ -8703,7 +8703,7 @@
       "kb_article": "KB5000842",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5000842"
     },
     {
       "full_version": "10.0.14393.4350",
@@ -8715,7 +8715,7 @@
       "kb_article": "KB5001347",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001347"
     },
     {
       "full_version": "10.0.14393.4350",
@@ -8727,7 +8727,7 @@
       "kb_article": "KB5001347",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001347"
     },
     {
       "full_version": "10.0.17134.2145",
@@ -8739,7 +8739,7 @@
       "kb_article": "KB5001339",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001339"
     },
     {
       "full_version": "10.0.17763.1879",
@@ -8751,7 +8751,7 @@
       "kb_article": "KB5001342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001342"
     },
     {
       "full_version": "10.0.17763.1879",
@@ -8763,7 +8763,7 @@
       "kb_article": "KB5001342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001342"
     },
     {
       "full_version": "10.0.18363.1500",
@@ -8775,7 +8775,7 @@
       "kb_article": "KB5001337",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001337"
     },
     {
       "full_version": "10.0.19041.928",
@@ -8787,7 +8787,7 @@
       "kb_article": "KB5001330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001330"
     },
     {
       "full_version": "10.0.19042.928",
@@ -8799,7 +8799,7 @@
       "kb_article": "KB5001330",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001330"
     },
     {
       "full_version": "10.0.17763.1911",
@@ -8811,7 +8811,7 @@
       "kb_article": "KB5001384",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001384"
     },
     {
       "full_version": "10.0.17763.1911",
@@ -8823,7 +8823,7 @@
       "kb_article": "KB5001384",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001384"
     },
     {
       "full_version": "10.0.18363.1533",
@@ -8835,7 +8835,7 @@
       "kb_article": "KB5001396",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001396"
     },
     {
       "full_version": "10.0.19041.964",
@@ -8847,7 +8847,7 @@
       "kb_article": "KB5001391",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001391"
     },
     {
       "full_version": "10.0.19042.964",
@@ -8859,7 +8859,7 @@
       "kb_article": "KB5001391",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5001391"
     },
     {
       "full_version": "10.0.14393.4402",
@@ -8871,7 +8871,7 @@
       "kb_article": "KB5003197",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003197"
     },
     {
       "full_version": "10.0.14393.4402",
@@ -8883,7 +8883,7 @@
       "kb_article": "KB5003197",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003197"
     },
     {
       "full_version": "10.0.17134.2208",
@@ -8895,7 +8895,7 @@
       "kb_article": "KB5003174",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003174"
     },
     {
       "full_version": "10.0.17763.1935",
@@ -8907,7 +8907,7 @@
       "kb_article": "KB5003171",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003171"
     },
     {
       "full_version": "10.0.17763.1935",
@@ -8919,7 +8919,7 @@
       "kb_article": "KB5003171",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003171"
     },
     {
       "full_version": "10.0.18363.1556",
@@ -8931,7 +8931,7 @@
       "kb_article": "KB5003169",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003169"
     },
     {
       "full_version": "10.0.19041.985",
@@ -8943,7 +8943,7 @@
       "kb_article": "KB5003173",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003173"
     },
     {
       "full_version": "10.0.19042.985",
@@ -8955,7 +8955,7 @@
       "kb_article": "KB5003173",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003173"
     },
     {
       "full_version": "10.0.19043.985",
@@ -8967,7 +8967,7 @@
       "kb_article": "KB5003173",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003173"
     },
     {
       "full_version": "10.0.17763.1971",
@@ -8979,7 +8979,7 @@
       "kb_article": "KB5003217",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003217"
     },
     {
       "full_version": "10.0.17763.1971",
@@ -8991,7 +8991,7 @@
       "kb_article": "KB5003217",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003217"
     },
     {
       "full_version": "10.0.18363.1593",
@@ -9003,7 +9003,7 @@
       "kb_article": "KB5003212",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003212"
     },
     {
       "full_version": "10.0.19041.1023",
@@ -9015,7 +9015,7 @@
       "kb_article": "KB5003214",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003214"
     },
     {
       "full_version": "10.0.19042.1023",
@@ -9027,7 +9027,7 @@
       "kb_article": "KB5003214",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003214"
     },
     {
       "full_version": "10.0.19043.1023",
@@ -9039,7 +9039,7 @@
       "kb_article": "KB5003214",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003214"
     },
     {
       "full_version": "10.0.14393.4467",
@@ -9051,7 +9051,7 @@
       "kb_article": "KB5003638",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003638"
     },
     {
       "full_version": "10.0.14393.4467",
@@ -9063,7 +9063,7 @@
       "kb_article": "KB5003638",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003638"
     },
     {
       "full_version": "10.0.17763.1999",
@@ -9075,7 +9075,7 @@
       "kb_article": "KB5003646",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003646"
     },
     {
       "full_version": "10.0.17763.1999",
@@ -9087,7 +9087,7 @@
       "kb_article": "KB5003646",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003646"
     },
     {
       "full_version": "10.0.18363.1621",
@@ -9099,7 +9099,7 @@
       "kb_article": "KB5003635",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003635"
     },
     {
       "full_version": "10.0.19041.1052",
@@ -9111,7 +9111,7 @@
       "kb_article": "KB5003637",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003637"
     },
     {
       "full_version": "10.0.19042.1052",
@@ -9123,7 +9123,7 @@
       "kb_article": "KB5003637",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003637"
     },
     {
       "full_version": "10.0.19043.1052",
@@ -9135,7 +9135,7 @@
       "kb_article": "KB5003637",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003637"
     },
     {
       "full_version": "10.0.19041.1055",
@@ -9147,7 +9147,7 @@
       "kb_article": "KB5004476",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004476"
     },
     {
       "full_version": "10.0.19042.1055",
@@ -9159,7 +9159,7 @@
       "kb_article": "KB5004476",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004476"
     },
     {
       "full_version": "10.0.19043.1055",
@@ -9171,7 +9171,7 @@
       "kb_article": "KB5004476",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004476"
     },
     {
       "full_version": "10.0.17763.2028",
@@ -9183,7 +9183,7 @@
       "kb_article": "KB5003703",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003703"
     },
     {
       "full_version": "10.0.17763.2028",
@@ -9195,7 +9195,7 @@
       "kb_article": "KB5003703",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003703"
     },
     {
       "full_version": "10.0.18363.1645",
@@ -9207,7 +9207,7 @@
       "kb_article": "KB5003698",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003698"
     },
     {
       "full_version": "10.0.19041.1081",
@@ -9219,7 +9219,7 @@
       "kb_article": "KB5003690",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003690"
     },
     {
       "full_version": "10.0.19042.1081",
@@ -9231,7 +9231,7 @@
       "kb_article": "KB5003690",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003690"
     },
     {
       "full_version": "10.0.19043.1081",
@@ -9243,7 +9243,7 @@
       "kb_article": "KB5003690",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5003690"
     },
     {
       "full_version": "10.0.19041.1082",
@@ -9255,7 +9255,7 @@
       "kb_article": "KB5004760",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004760"
     },
     {
       "full_version": "10.0.19042.1082",
@@ -9267,7 +9267,7 @@
       "kb_article": "KB5004760",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004760"
     },
     {
       "full_version": "10.0.19043.1082",
@@ -9279,7 +9279,7 @@
       "kb_article": "KB5004760",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004760"
     },
     {
       "full_version": "10.0.17763.2029",
@@ -9291,7 +9291,7 @@
       "kb_article": "KB5004947",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004947"
     },
     {
       "full_version": "10.0.17763.2029",
@@ -9303,7 +9303,7 @@
       "kb_article": "KB5004947",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004947"
     },
     {
       "full_version": "10.0.18363.1646",
@@ -9315,7 +9315,7 @@
       "kb_article": "KB5004946",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004946"
     },
     {
       "full_version": "10.0.19041.1083",
@@ -9327,7 +9327,7 @@
       "kb_article": "KB5004945",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004945"
     },
     {
       "full_version": "10.0.19042.1083",
@@ -9339,7 +9339,7 @@
       "kb_article": "KB5004945",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004945"
     },
     {
       "full_version": "10.0.19043.1083",
@@ -9351,7 +9351,7 @@
       "kb_article": "KB5004945",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004945"
     },
     {
       "full_version": "10.0.14393.4470",
@@ -9363,7 +9363,7 @@
       "kb_article": "KB5004948",
       "release_type": "Out-of-band",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004948"
     },
     {
       "full_version": "10.0.14393.4470",
@@ -9375,7 +9375,7 @@
       "kb_article": "KB5004948",
       "release_type": "Out-of-band",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004948"
     },
     {
       "full_version": "10.0.14393.4530",
@@ -9387,7 +9387,7 @@
       "kb_article": "KB5004238",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004238"
     },
     {
       "full_version": "10.0.14393.4530",
@@ -9399,7 +9399,7 @@
       "kb_article": "KB5004238",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004238"
     },
     {
       "full_version": "10.0.17763.2061",
@@ -9411,7 +9411,7 @@
       "kb_article": "KB5004244",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004244"
     },
     {
       "full_version": "10.0.17763.2061",
@@ -9423,7 +9423,7 @@
       "kb_article": "KB5004244",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004244"
     },
     {
       "full_version": "10.0.18363.1679",
@@ -9435,7 +9435,7 @@
       "kb_article": "KB5004245",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004245"
     },
     {
       "full_version": "10.0.19041.1110",
@@ -9447,7 +9447,7 @@
       "kb_article": "KB5004237",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004237"
     },
     {
       "full_version": "10.0.19042.1110",
@@ -9459,7 +9459,7 @@
       "kb_article": "KB5004237",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004237"
     },
     {
       "full_version": "10.0.19043.1110",
@@ -9471,7 +9471,7 @@
       "kb_article": "KB5004237",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004237"
     },
     {
       "full_version": "10.0.17763.2090",
@@ -9483,7 +9483,7 @@
       "kb_article": "KB5004308",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004308"
     },
     {
       "full_version": "10.0.17763.2090",
@@ -9495,7 +9495,7 @@
       "kb_article": "KB5004308",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004308"
     },
     {
       "full_version": "10.0.17763.2091",
@@ -9507,7 +9507,7 @@
       "kb_article": "KB5005394",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005394"
     },
     {
       "full_version": "10.0.17763.2091",
@@ -9519,7 +9519,7 @@
       "kb_article": "KB5005394",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005394"
     },
     {
       "full_version": "10.0.14393.4532",
@@ -9531,7 +9531,7 @@
       "kb_article": "KB5005393",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005393"
     },
     {
       "full_version": "10.0.14393.4532",
@@ -9543,7 +9543,7 @@
       "kb_article": "KB5005393",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005393"
     },
     {
       "full_version": "10.0.18363.1714",
@@ -9555,7 +9555,7 @@
       "kb_article": "KB5004293",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004293"
     },
     {
       "full_version": "10.0.19041.1151",
@@ -9567,7 +9567,7 @@
       "kb_article": "KB5004296",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004296"
     },
     {
       "full_version": "10.0.19042.1151",
@@ -9579,7 +9579,7 @@
       "kb_article": "KB5004296",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004296"
     },
     {
       "full_version": "10.0.19043.1151",
@@ -9591,7 +9591,7 @@
       "kb_article": "KB5004296",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5004296"
     },
     {
       "full_version": "10.0.14393.4583",
@@ -9603,7 +9603,7 @@
       "kb_article": "KB5005043",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005043"
     },
     {
       "full_version": "10.0.14393.4583",
@@ -9615,7 +9615,7 @@
       "kb_article": "KB5005043",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005043"
     },
     {
       "full_version": "10.0.17763.2114",
@@ -9627,7 +9627,7 @@
       "kb_article": "KB5005030",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005030"
     },
     {
       "full_version": "10.0.17763.2114",
@@ -9639,7 +9639,7 @@
       "kb_article": "KB5005030",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005030"
     },
     {
       "full_version": "10.0.18363.1734",
@@ -9651,7 +9651,7 @@
       "kb_article": "KB5005031",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005031"
     },
     {
       "full_version": "10.0.19041.1165",
@@ -9663,7 +9663,7 @@
       "kb_article": "KB5005033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005033"
     },
     {
       "full_version": "10.0.19042.1165",
@@ -9675,7 +9675,7 @@
       "kb_article": "KB5005033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005033"
     },
     {
       "full_version": "10.0.19043.1165",
@@ -9687,7 +9687,7 @@
       "kb_article": "KB5005033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005033"
     },
     {
       "full_version": "10.0.17763.2145",
@@ -9699,7 +9699,7 @@
       "kb_article": "KB5005102",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005102"
     },
     {
       "full_version": "10.0.17763.2145",
@@ -9711,7 +9711,7 @@
       "kb_article": "KB5005102",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005102"
     },
     {
       "full_version": "10.0.18363.1766",
@@ -9723,7 +9723,7 @@
       "kb_article": "KB5005103",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005103"
     },
     {
       "full_version": "10.0.19041.1202",
@@ -9735,7 +9735,7 @@
       "kb_article": "KB5005101",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005101"
     },
     {
       "full_version": "10.0.19042.1202",
@@ -9747,7 +9747,7 @@
       "kb_article": "KB5005101",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005101"
     },
     {
       "full_version": "10.0.19043.1202",
@@ -9759,7 +9759,7 @@
       "kb_article": "KB5005101",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005101"
     },
     {
       "full_version": "10.0.14393.4651",
@@ -9771,7 +9771,7 @@
       "kb_article": "KB5005573",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005573"
     },
     {
       "full_version": "10.0.14393.4651",
@@ -9783,7 +9783,7 @@
       "kb_article": "KB5005573",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005573"
     },
     {
       "full_version": "10.0.17763.2183",
@@ -9795,7 +9795,7 @@
       "kb_article": "KB5005568",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005568"
     },
     {
       "full_version": "10.0.17763.2183",
@@ -9807,7 +9807,7 @@
       "kb_article": "KB5005568",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005568"
     },
     {
       "full_version": "10.0.18363.1801",
@@ -9819,7 +9819,7 @@
       "kb_article": "KB5005566",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005566"
     },
     {
       "full_version": "10.0.19041.1237",
@@ -9831,7 +9831,7 @@
       "kb_article": "KB5005565",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005565"
     },
     {
       "full_version": "10.0.19042.1237",
@@ -9843,7 +9843,7 @@
       "kb_article": "KB5005565",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005565"
     },
     {
       "full_version": "10.0.19043.1237",
@@ -9855,7 +9855,7 @@
       "kb_article": "KB5005565",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005565"
     },
     {
       "full_version": "10.0.20348.230",
@@ -9867,7 +9867,7 @@
       "kb_article": "KB5005575",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005575"
     },
     {
       "full_version": "10.0.17763.2210",
@@ -9879,7 +9879,7 @@
       "kb_article": "KB5005625",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005625"
     },
     {
       "full_version": "10.0.17763.2210",
@@ -9891,7 +9891,7 @@
       "kb_article": "KB5005625",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005625"
     },
     {
       "full_version": "10.0.18363.1830",
@@ -9903,7 +9903,7 @@
       "kb_article": "KB5005624",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005624"
     },
     {
       "full_version": "10.0.20348.261",
@@ -9915,7 +9915,7 @@
       "kb_article": "KB5005619",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005619"
     },
     {
       "full_version": "10.0.19041.1266",
@@ -9927,7 +9927,7 @@
       "kb_article": "KB5005611",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005611"
     },
     {
       "full_version": "10.0.19042.1266",
@@ -9939,7 +9939,7 @@
       "kb_article": "KB5005611",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005611"
     },
     {
       "full_version": "10.0.19043.1266",
@@ -9951,7 +9951,7 @@
       "kb_article": "KB5005611",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5005611"
     },
     {
       "full_version": "10.0.14393.4704",
@@ -9963,7 +9963,7 @@
       "kb_article": "KB5006669",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006669"
     },
     {
       "full_version": "10.0.14393.4704",
@@ -9975,7 +9975,7 @@
       "kb_article": "KB5006669",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006669"
     },
     {
       "full_version": "10.0.17763.2237",
@@ -9987,7 +9987,7 @@
       "kb_article": "KB5006672",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006672"
     },
     {
       "full_version": "10.0.17763.2237",
@@ -9999,7 +9999,7 @@
       "kb_article": "KB5006672",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006672"
     },
     {
       "full_version": "10.0.18363.1854",
@@ -10011,7 +10011,7 @@
       "kb_article": "KB5006667",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006667"
     },
     {
       "full_version": "10.0.19041.1288",
@@ -10023,7 +10023,7 @@
       "kb_article": "KB5006670",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006670"
     },
     {
       "full_version": "10.0.19042.1288",
@@ -10035,7 +10035,7 @@
       "kb_article": "KB5006670",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006670"
     },
     {
       "full_version": "10.0.19043.1288",
@@ -10047,7 +10047,7 @@
       "kb_article": "KB5006670",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006670"
     },
     {
       "full_version": "10.0.20348.288",
@@ -10059,7 +10059,7 @@
       "kb_article": "KB5006699",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006699"
     },
     {
       "full_version": "10.0.22000.258",
@@ -10071,7 +10071,7 @@
       "kb_article": "KB5006674",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006674"
     },
     {
       "full_version": "10.0.17763.2268",
@@ -10083,7 +10083,7 @@
       "kb_article": "KB5006744",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006744"
     },
     {
       "full_version": "10.0.17763.2268",
@@ -10095,7 +10095,7 @@
       "kb_article": "KB5006744",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006744"
     },
     {
       "full_version": "10.0.22000.282",
@@ -10107,7 +10107,7 @@
       "kb_article": "KB5006746",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006746"
     },
     {
       "full_version": "10.0.19041.1320",
@@ -10119,7 +10119,7 @@
       "kb_article": "KB5006738",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006738"
     },
     {
       "full_version": "10.0.19042.1320",
@@ -10131,7 +10131,7 @@
       "kb_article": "KB5006738",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006738"
     },
     {
       "full_version": "10.0.19043.1320",
@@ -10143,7 +10143,7 @@
       "kb_article": "KB5006738",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006738"
     },
     {
       "full_version": "10.0.20348.320",
@@ -10155,7 +10155,7 @@
       "kb_article": "KB5006745",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5006745"
     },
     {
       "full_version": "10.0.14393.4770",
@@ -10167,7 +10167,7 @@
       "kb_article": "KB5007192",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007192"
     },
     {
       "full_version": "10.0.14393.4770",
@@ -10179,7 +10179,7 @@
       "kb_article": "KB5007192",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007192"
     },
     {
       "full_version": "10.0.17763.2300",
@@ -10191,7 +10191,7 @@
       "kb_article": "KB5007206",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007206"
     },
     {
       "full_version": "10.0.17763.2300",
@@ -10203,7 +10203,7 @@
       "kb_article": "KB5007206",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007206"
     },
     {
       "full_version": "10.0.18363.1916",
@@ -10215,7 +10215,7 @@
       "kb_article": "KB5007189",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007189"
     },
     {
       "full_version": "10.0.19041.1348",
@@ -10227,7 +10227,7 @@
       "kb_article": "KB5007186",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007186"
     },
     {
       "full_version": "10.0.19042.1348",
@@ -10239,7 +10239,7 @@
       "kb_article": "KB5007186",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007186"
     },
     {
       "full_version": "10.0.19043.1348",
@@ -10251,7 +10251,7 @@
       "kb_article": "KB5007186",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007186"
     },
     {
       "full_version": "10.0.20348.350",
@@ -10263,7 +10263,7 @@
       "kb_article": "KB5007205",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007205"
     },
     {
       "full_version": "10.0.22000.318",
@@ -10275,7 +10275,7 @@
       "kb_article": "KB5007215",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007215"
     },
     {
       "full_version": "10.0.14393.4771",
@@ -10287,7 +10287,7 @@
       "kb_article": "KB5008601",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008601"
     },
     {
       "full_version": "10.0.14393.4771",
@@ -10299,7 +10299,7 @@
       "kb_article": "KB5008601",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008601"
     },
     {
       "full_version": "10.0.17763.2305",
@@ -10311,7 +10311,7 @@
       "kb_article": "KB5008602",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008602"
     },
     {
       "full_version": "10.0.17763.2305",
@@ -10323,7 +10323,7 @@
       "kb_article": "KB5008602",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008602"
     },
     {
       "full_version": "10.0.17763.2330",
@@ -10335,7 +10335,7 @@
       "kb_article": "KB5007266",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007266"
     },
     {
       "full_version": "10.0.17763.2330",
@@ -10347,7 +10347,7 @@
       "kb_article": "KB5007266",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007266"
     },
     {
       "full_version": "10.0.19041.1387",
@@ -10359,7 +10359,7 @@
       "kb_article": "KB5007253",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007253"
     },
     {
       "full_version": "10.0.19042.1387",
@@ -10371,7 +10371,7 @@
       "kb_article": "KB5007253",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007253"
     },
     {
       "full_version": "10.0.19043.1387",
@@ -10383,7 +10383,7 @@
       "kb_article": "KB5007253",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007253"
     },
     {
       "full_version": "10.0.19044.1387",
@@ -10395,7 +10395,7 @@
       "kb_article": "KB5007253",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007253"
     },
     {
       "full_version": "10.0.20348.380",
@@ -10407,7 +10407,7 @@
       "kb_article": "KB5007254",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007254"
     },
     {
       "full_version": "10.0.22000.348",
@@ -10419,7 +10419,7 @@
       "kb_article": "KB5007262",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5007262"
     },
     {
       "full_version": "10.0.14393.4825",
@@ -10431,7 +10431,7 @@
       "kb_article": "KB5008207",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008207"
     },
     {
       "full_version": "10.0.14393.4825",
@@ -10443,7 +10443,7 @@
       "kb_article": "KB5008207",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008207"
     },
     {
       "full_version": "10.0.17763.2366",
@@ -10455,7 +10455,7 @@
       "kb_article": "KB5008218",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008218"
     },
     {
       "full_version": "10.0.17763.2366",
@@ -10467,7 +10467,7 @@
       "kb_article": "KB5008218",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008218"
     },
     {
       "full_version": "10.0.18363.1977",
@@ -10479,7 +10479,7 @@
       "kb_article": "KB5008206",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008206"
     },
     {
       "full_version": "10.0.19041.1415",
@@ -10491,7 +10491,7 @@
       "kb_article": "KB5008212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008212"
     },
     {
       "full_version": "10.0.19042.1415",
@@ -10503,7 +10503,7 @@
       "kb_article": "KB5008212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008212"
     },
     {
       "full_version": "10.0.19043.1415",
@@ -10515,7 +10515,7 @@
       "kb_article": "KB5008212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008212"
     },
     {
       "full_version": "10.0.19044.1415",
@@ -10527,7 +10527,7 @@
       "kb_article": "KB5008212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008212"
     },
     {
       "full_version": "10.0.20348.405",
@@ -10539,7 +10539,7 @@
       "kb_article": "KB5008223",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008223"
     },
     {
       "full_version": "10.0.22000.376",
@@ -10551,7 +10551,7 @@
       "kb_article": "KB5008215",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008215"
     },
     {
       "full_version": "10.0.17763.2369",
@@ -10563,7 +10563,7 @@
       "kb_article": "KB5010196",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010196"
     },
     {
       "full_version": "10.0.17763.2369",
@@ -10575,7 +10575,7 @@
       "kb_article": "KB5010196",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010196"
     },
     {
       "full_version": "10.0.14393.4827",
@@ -10587,7 +10587,7 @@
       "kb_article": "KB5010195",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010195"
     },
     {
       "full_version": "10.0.14393.4827",
@@ -10599,7 +10599,7 @@
       "kb_article": "KB5010195",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010195"
     },
     {
       "full_version": "10.0.20348.407",
@@ -10611,7 +10611,7 @@
       "kb_article": "KB5010197",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010197"
     },
     {
       "full_version": "10.0.14393.4886",
@@ -10623,7 +10623,7 @@
       "kb_article": "KB5009546",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009546"
     },
     {
       "full_version": "10.0.14393.4886",
@@ -10635,7 +10635,7 @@
       "kb_article": "KB5009546",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009546"
     },
     {
       "full_version": "10.0.17763.2452",
@@ -10647,7 +10647,7 @@
       "kb_article": "KB5009557",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009557"
     },
     {
       "full_version": "10.0.17763.2452",
@@ -10659,7 +10659,7 @@
       "kb_article": "KB5009557",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009557"
     },
     {
       "full_version": "10.0.18363.2037",
@@ -10671,7 +10671,7 @@
       "kb_article": "KB5009545",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009545"
     },
     {
       "full_version": "10.0.19042.1466",
@@ -10683,7 +10683,7 @@
       "kb_article": "KB5009543",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009543"
     },
     {
       "full_version": "10.0.19043.1466",
@@ -10695,7 +10695,7 @@
       "kb_article": "KB5009543",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009543"
     },
     {
       "full_version": "10.0.19044.1466",
@@ -10707,7 +10707,7 @@
       "kb_article": "KB5009543",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009543"
     },
     {
       "full_version": "10.0.20348.469",
@@ -10719,7 +10719,7 @@
       "kb_article": "KB5009555",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009555"
     },
     {
       "full_version": "10.0.22000.434",
@@ -10731,7 +10731,7 @@
       "kb_article": "KB5009566",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009566"
     },
     {
       "full_version": "10.0.14393.4889",
@@ -10743,7 +10743,7 @@
       "kb_article": "KB5010790",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010790"
     },
     {
       "full_version": "10.0.14393.4889",
@@ -10755,7 +10755,7 @@
       "kb_article": "KB5010790",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010790"
     },
     {
       "full_version": "10.0.18363.2039",
@@ -10767,7 +10767,7 @@
       "kb_article": "KB5010792",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010792"
     },
     {
       "full_version": "10.0.19042.1469",
@@ -10779,7 +10779,7 @@
       "kb_article": "KB5010793",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010793"
     },
     {
       "full_version": "10.0.19043.1469",
@@ -10791,7 +10791,7 @@
       "kb_article": "KB5010793",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010793"
     },
     {
       "full_version": "10.0.19044.1469",
@@ -10803,7 +10803,7 @@
       "kb_article": "KB5010793",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010793"
     },
     {
       "full_version": "10.0.20348.473",
@@ -10815,7 +10815,7 @@
       "kb_article": "KB5010796",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010796"
     },
     {
       "full_version": "10.0.22000.438",
@@ -10827,7 +10827,7 @@
       "kb_article": "KB5010795",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010795"
     },
     {
       "full_version": "10.0.17763.2458",
@@ -10839,7 +10839,7 @@
       "kb_article": "KB5010791",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010791"
     },
     {
       "full_version": "10.0.17763.2458",
@@ -10851,7 +10851,7 @@
       "kb_article": "KB5010791",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010791"
     },
     {
       "full_version": "10.0.17763.2510",
@@ -10863,7 +10863,7 @@
       "kb_article": "KB5009616",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009616"
     },
     {
       "full_version": "10.0.17763.2510",
@@ -10875,7 +10875,7 @@
       "kb_article": "KB5009616",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009616"
     },
     {
       "full_version": "10.0.19042.1503",
@@ -10887,7 +10887,7 @@
       "kb_article": "KB5009596",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009596"
     },
     {
       "full_version": "10.0.19043.1503",
@@ -10899,7 +10899,7 @@
       "kb_article": "KB5009596",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009596"
     },
     {
       "full_version": "10.0.19044.1503",
@@ -10911,7 +10911,7 @@
       "kb_article": "KB5009596",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009596"
     },
     {
       "full_version": "10.0.20348.502",
@@ -10923,7 +10923,7 @@
       "kb_article": "KB5009608",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5009608"
     },
     {
       "full_version": "10.0.22000.469",
@@ -10935,7 +10935,7 @@
       "kb_article": "KB5008353",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5008353"
     },
     {
       "full_version": "10.0.14393.4946",
@@ -10947,7 +10947,7 @@
       "kb_article": "KB5010359",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010359"
     },
     {
       "full_version": "10.0.14393.4946",
@@ -10959,7 +10959,7 @@
       "kb_article": "KB5010359",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010359"
     },
     {
       "full_version": "10.0.17763.2565",
@@ -10971,7 +10971,7 @@
       "kb_article": "KB5010351",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010351"
     },
     {
       "full_version": "10.0.17763.2565",
@@ -10983,7 +10983,7 @@
       "kb_article": "KB5010351",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010351"
     },
     {
       "full_version": "10.0.18363.2094",
@@ -10995,7 +10995,7 @@
       "kb_article": "KB5010345",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010345"
     },
     {
       "full_version": "10.0.19042.1526",
@@ -11007,7 +11007,7 @@
       "kb_article": "KB5010342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010342"
     },
     {
       "full_version": "10.0.19043.1526",
@@ -11019,7 +11019,7 @@
       "kb_article": "KB5010342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010342"
     },
     {
       "full_version": "10.0.19044.1526",
@@ -11031,7 +11031,7 @@
       "kb_article": "KB5010342",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010342"
     },
     {
       "full_version": "10.0.20348.524",
@@ -11043,7 +11043,7 @@
       "kb_article": "KB5010354",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010354"
     },
     {
       "full_version": "10.0.22000.493",
@@ -11055,7 +11055,7 @@
       "kb_article": "KB5010386",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010386"
     },
     {
       "full_version": "10.0.17763.2628",
@@ -11067,7 +11067,7 @@
       "kb_article": "KB5010427",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010427"
     },
     {
       "full_version": "10.0.17763.2628",
@@ -11079,7 +11079,7 @@
       "kb_article": "KB5010427",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010427"
     },
     {
       "full_version": "10.0.19042.1566",
@@ -11091,7 +11091,7 @@
       "kb_article": "KB5010415",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010415"
     },
     {
       "full_version": "10.0.19043.1566",
@@ -11103,7 +11103,7 @@
       "kb_article": "KB5010415",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010415"
     },
     {
       "full_version": "10.0.19044.1566",
@@ -11115,7 +11115,7 @@
       "kb_article": "KB5010415",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010415"
     },
     {
       "full_version": "10.0.20348.558",
@@ -11127,7 +11127,7 @@
       "kb_article": "KB5010421",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010421"
     },
     {
       "full_version": "10.0.22000.527",
@@ -11139,7 +11139,7 @@
       "kb_article": "KB5010414",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5010414"
     },
     {
       "full_version": "10.0.14393.5006",
@@ -11151,7 +11151,7 @@
       "kb_article": "KB5011495",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011495"
     },
     {
       "full_version": "10.0.14393.5006",
@@ -11163,7 +11163,7 @@
       "kb_article": "KB5011495",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011495"
     },
     {
       "full_version": "10.0.17763.2686",
@@ -11175,7 +11175,7 @@
       "kb_article": "KB5011503",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011503"
     },
     {
       "full_version": "10.0.17763.2686",
@@ -11187,7 +11187,7 @@
       "kb_article": "KB5011503",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011503"
     },
     {
       "full_version": "10.0.18363.2158",
@@ -11199,7 +11199,7 @@
       "kb_article": "KB5011485",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011485"
     },
     {
       "full_version": "10.0.19042.1586",
@@ -11211,7 +11211,7 @@
       "kb_article": "KB5011487",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011487"
     },
     {
       "full_version": "10.0.19043.1586",
@@ -11223,7 +11223,7 @@
       "kb_article": "KB5011487",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011487"
     },
     {
       "full_version": "10.0.19044.1586",
@@ -11235,7 +11235,7 @@
       "kb_article": "KB5011487",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011487"
     },
     {
       "full_version": "10.0.20348.587",
@@ -11247,7 +11247,7 @@
       "kb_article": "KB5011497",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011497"
     },
     {
       "full_version": "10.0.22000.556",
@@ -11259,7 +11259,7 @@
       "kb_article": "KB5011493",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011493"
     },
     {
       "full_version": "10.0.17763.2746",
@@ -11271,7 +11271,7 @@
       "kb_article": "KB5011551",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011551"
     },
     {
       "full_version": "10.0.17763.2746",
@@ -11283,7 +11283,7 @@
       "kb_article": "KB5011551",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011551"
     },
     {
       "full_version": "10.0.19042.1620",
@@ -11295,7 +11295,7 @@
       "kb_article": "KB5011543",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011543"
     },
     {
       "full_version": "10.0.19043.1620",
@@ -11307,7 +11307,7 @@
       "kb_article": "KB5011543",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011543"
     },
     {
       "full_version": "10.0.19044.1620",
@@ -11319,7 +11319,7 @@
       "kb_article": "KB5011543",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011543"
     },
     {
       "full_version": "10.0.20348.617",
@@ -11331,7 +11331,7 @@
       "kb_article": "KB5011558",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011558"
     },
     {
       "full_version": "10.0.22000.593",
@@ -11343,7 +11343,7 @@
       "kb_article": "KB5011563",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011563"
     },
     {
       "full_version": "10.0.14393.5066",
@@ -11355,7 +11355,7 @@
       "kb_article": "KB5012596",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012596"
     },
     {
       "full_version": "10.0.14393.5066",
@@ -11367,7 +11367,7 @@
       "kb_article": "KB5012596",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012596"
     },
     {
       "full_version": "10.0.17763.2803",
@@ -11379,7 +11379,7 @@
       "kb_article": "KB5012647",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012647"
     },
     {
       "full_version": "10.0.17763.2803",
@@ -11391,7 +11391,7 @@
       "kb_article": "KB5012647",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012647"
     },
     {
       "full_version": "10.0.18363.2212",
@@ -11403,7 +11403,7 @@
       "kb_article": "KB5012591",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012591"
     },
     {
       "full_version": "10.0.19042.1645",
@@ -11415,7 +11415,7 @@
       "kb_article": "KB5012599",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012599"
     },
     {
       "full_version": "10.0.19043.1645",
@@ -11427,7 +11427,7 @@
       "kb_article": "KB5012599",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012599"
     },
     {
       "full_version": "10.0.19044.1645",
@@ -11439,7 +11439,7 @@
       "kb_article": "KB5012599",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012599"
     },
     {
       "full_version": "10.0.20348.643",
@@ -11451,7 +11451,7 @@
       "kb_article": "KB5012604",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012604"
     },
     {
       "full_version": "10.0.22000.613",
@@ -11463,7 +11463,7 @@
       "kb_article": "KB5012592",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012592"
     },
     {
       "full_version": "10.0.17763.2867",
@@ -11475,7 +11475,7 @@
       "kb_article": "KB5012636",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012636"
     },
     {
       "full_version": "10.0.17763.2867",
@@ -11487,7 +11487,7 @@
       "kb_article": "KB5012636",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012636"
     },
     {
       "full_version": "10.0.19042.1682",
@@ -11499,7 +11499,7 @@
       "kb_article": "KB5011831",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011831"
     },
     {
       "full_version": "10.0.19043.1682",
@@ -11511,7 +11511,7 @@
       "kb_article": "KB5011831",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011831"
     },
     {
       "full_version": "10.0.19044.1682",
@@ -11523,7 +11523,7 @@
       "kb_article": "KB5011831",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5011831"
     },
     {
       "full_version": "10.0.20348.681",
@@ -11535,7 +11535,7 @@
       "kb_article": "KB5012637",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012637"
     },
     {
       "full_version": "10.0.22000.652",
@@ -11547,7 +11547,7 @@
       "kb_article": "KB5012643",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5012643"
     },
     {
       "full_version": "10.0.14393.5125",
@@ -11559,7 +11559,7 @@
       "kb_article": "KB5013952",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013952"
     },
     {
       "full_version": "10.0.14393.5125",
@@ -11571,7 +11571,7 @@
       "kb_article": "KB5013952",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013952"
     },
     {
       "full_version": "10.0.17763.2928",
@@ -11583,7 +11583,7 @@
       "kb_article": "KB5013941",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013941"
     },
     {
       "full_version": "10.0.17763.2928",
@@ -11595,7 +11595,7 @@
       "kb_article": "KB5013941",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013941"
     },
     {
       "full_version": "10.0.18363.2274",
@@ -11607,7 +11607,7 @@
       "kb_article": "KB5013945",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013945"
     },
     {
       "full_version": "10.0.19042.1706",
@@ -11619,7 +11619,7 @@
       "kb_article": "KB5013942",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013942"
     },
     {
       "full_version": "10.0.19043.1706",
@@ -11631,7 +11631,7 @@
       "kb_article": "KB5013942",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013942"
     },
     {
       "full_version": "10.0.19044.1706",
@@ -11643,7 +11643,7 @@
       "kb_article": "KB5013942",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013942"
     },
     {
       "full_version": "10.0.20348.707",
@@ -11655,7 +11655,7 @@
       "kb_article": "KB5013944",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013944"
     },
     {
       "full_version": "10.0.22000.675",
@@ -11667,7 +11667,7 @@
       "kb_article": "KB5013943",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5013943"
     },
     {
       "full_version": "10.0.17763.2931",
@@ -11679,7 +11679,7 @@
       "kb_article": "KB5015018",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015018"
     },
     {
       "full_version": "10.0.17763.2931",
@@ -11691,7 +11691,7 @@
       "kb_article": "KB5015018",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015018"
     },
     {
       "full_version": "10.0.19042.1708",
@@ -11703,7 +11703,7 @@
       "kb_article": "KB5015020",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015020"
     },
     {
       "full_version": "10.0.19043.1708",
@@ -11715,7 +11715,7 @@
       "kb_article": "KB5015020",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015020"
     },
     {
       "full_version": "10.0.19044.1708",
@@ -11727,7 +11727,7 @@
       "kb_article": "KB5015020",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015020"
     },
     {
       "full_version": "10.0.20348.709",
@@ -11739,7 +11739,7 @@
       "kb_article": "KB5015013",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015013"
     },
     {
       "full_version": "10.0.17763.2989",
@@ -11751,7 +11751,7 @@
       "kb_article": "KB5014022",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014022"
     },
     {
       "full_version": "10.0.17763.2989",
@@ -11763,7 +11763,7 @@
       "kb_article": "KB5014022",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014022"
     },
     {
       "full_version": "10.0.20348.740",
@@ -11775,7 +11775,7 @@
       "kb_article": "KB5014021",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014021"
     },
     {
       "full_version": "10.0.22000.708",
@@ -11787,7 +11787,7 @@
       "kb_article": "KB5014019",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014019"
     },
     {
       "full_version": "10.0.19042.1741",
@@ -11799,7 +11799,7 @@
       "kb_article": "KB5014023",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014023"
     },
     {
       "full_version": "10.0.19043.1741",
@@ -11811,7 +11811,7 @@
       "kb_article": "KB5014023",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014023"
     },
     {
       "full_version": "10.0.19044.1741",
@@ -11823,7 +11823,7 @@
       "kb_article": "KB5014023",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014023"
     },
     {
       "full_version": "10.0.14393.5192",
@@ -11835,7 +11835,7 @@
       "kb_article": "KB5014702",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014702"
     },
     {
       "full_version": "10.0.14393.5192",
@@ -11847,7 +11847,7 @@
       "kb_article": "KB5014702",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014702"
     },
     {
       "full_version": "10.0.17763.3046",
@@ -11859,7 +11859,7 @@
       "kb_article": "KB5014692",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014692"
     },
     {
       "full_version": "10.0.17763.3046",
@@ -11871,7 +11871,7 @@
       "kb_article": "KB5014692",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014692"
     },
     {
       "full_version": "10.0.19042.1766",
@@ -11883,7 +11883,7 @@
       "kb_article": "KB5014699",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014699"
     },
     {
       "full_version": "10.0.19043.1766",
@@ -11895,7 +11895,7 @@
       "kb_article": "KB5014699",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014699"
     },
     {
       "full_version": "10.0.19044.1766",
@@ -11907,7 +11907,7 @@
       "kb_article": "KB5014699",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014699"
     },
     {
       "full_version": "10.0.20348.768",
@@ -11919,7 +11919,7 @@
       "kb_article": "KB5014678",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014678"
     },
     {
       "full_version": "10.0.22000.739",
@@ -11931,7 +11931,7 @@
       "kb_article": "KB5014697",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014697"
     },
     {
       "full_version": "10.0.19042.1767",
@@ -11943,7 +11943,7 @@
       "kb_article": "KB5016139",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016139"
     },
     {
       "full_version": "10.0.19043.1767",
@@ -11955,7 +11955,7 @@
       "kb_article": "KB5016139",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016139"
     },
     {
       "full_version": "10.0.19044.1767",
@@ -11967,7 +11967,7 @@
       "kb_article": "KB5016139",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016139"
     },
     {
       "full_version": "10.0.22000.740",
@@ -11979,7 +11979,7 @@
       "kb_article": "KB5016138",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016138"
     },
     {
       "full_version": "10.0.17763.3113",
@@ -11991,7 +11991,7 @@
       "kb_article": "KB5014669",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014669"
     },
     {
       "full_version": "10.0.17763.3113",
@@ -12003,7 +12003,7 @@
       "kb_article": "KB5014669",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014669"
     },
     {
       "full_version": "10.0.20348.803",
@@ -12015,7 +12015,7 @@
       "kb_article": "KB5014665",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014665"
     },
     {
       "full_version": "10.0.22000.778",
@@ -12027,7 +12027,7 @@
       "kb_article": "KB5014668",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014668"
     },
     {
       "full_version": "10.0.19042.1806",
@@ -12039,7 +12039,7 @@
       "kb_article": "KB5014666",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014666"
     },
     {
       "full_version": "10.0.19043.1806",
@@ -12051,7 +12051,7 @@
       "kb_article": "KB5014666",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014666"
     },
     {
       "full_version": "10.0.19044.1806",
@@ -12063,7 +12063,7 @@
       "kb_article": "KB5014666",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5014666"
     },
     {
       "full_version": "10.0.14393.5246",
@@ -12075,7 +12075,7 @@
       "kb_article": "KB5015808",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015808"
     },
     {
       "full_version": "10.0.14393.5246",
@@ -12087,7 +12087,7 @@
       "kb_article": "KB5015808",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015808"
     },
     {
       "full_version": "10.0.17763.3165",
@@ -12099,7 +12099,7 @@
       "kb_article": "KB5015811",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015811"
     },
     {
       "full_version": "10.0.17763.3165",
@@ -12111,7 +12111,7 @@
       "kb_article": "KB5015811",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015811"
     },
     {
       "full_version": "10.0.19042.1826",
@@ -12123,7 +12123,7 @@
       "kb_article": "KB5015807",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015807"
     },
     {
       "full_version": "10.0.19043.1826",
@@ -12135,7 +12135,7 @@
       "kb_article": "KB5015807",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015807"
     },
     {
       "full_version": "10.0.19044.1826",
@@ -12147,7 +12147,7 @@
       "kb_article": "KB5015807",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015807"
     },
     {
       "full_version": "10.0.20348.825",
@@ -12159,7 +12159,7 @@
       "kb_article": "KB5015827",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015827"
     },
     {
       "full_version": "10.0.22000.795",
@@ -12171,7 +12171,7 @@
       "kb_article": "KB5015814",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015814"
     },
     {
       "full_version": "10.0.20348.859",
@@ -12183,7 +12183,7 @@
       "kb_article": "KB5015879",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015879"
     },
     {
       "full_version": "10.0.17763.3232",
@@ -12195,7 +12195,7 @@
       "kb_article": "KB5015880",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015880"
     },
     {
       "full_version": "10.0.17763.3232",
@@ -12207,7 +12207,7 @@
       "kb_article": "KB5015880",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015880"
     },
     {
       "full_version": "10.0.22000.832",
@@ -12219,7 +12219,7 @@
       "kb_article": "KB5015882",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015882"
     },
     {
       "full_version": "10.0.19042.1865",
@@ -12231,7 +12231,7 @@
       "kb_article": "KB5015878",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015878"
     },
     {
       "full_version": "10.0.19043.1865",
@@ -12243,7 +12243,7 @@
       "kb_article": "KB5015878",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015878"
     },
     {
       "full_version": "10.0.19044.1865",
@@ -12255,7 +12255,7 @@
       "kb_article": "KB5015878",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5015878"
     },
     {
       "full_version": "10.0.14393.5291",
@@ -12267,7 +12267,7 @@
       "kb_article": "KB5016622",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016622"
     },
     {
       "full_version": "10.0.14393.5291",
@@ -12279,7 +12279,7 @@
       "kb_article": "KB5016622",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016622"
     },
     {
       "full_version": "10.0.17763.3287",
@@ -12291,7 +12291,7 @@
       "kb_article": "KB5016623",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016623"
     },
     {
       "full_version": "10.0.17763.3287",
@@ -12303,7 +12303,7 @@
       "kb_article": "KB5016623",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016623"
     },
     {
       "full_version": "10.0.19042.1889",
@@ -12315,7 +12315,7 @@
       "kb_article": "KB5016616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016616"
     },
     {
       "full_version": "10.0.19043.1889",
@@ -12327,7 +12327,7 @@
       "kb_article": "KB5016616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016616"
     },
     {
       "full_version": "10.0.19044.1889",
@@ -12339,7 +12339,7 @@
       "kb_article": "KB5016616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016616"
     },
     {
       "full_version": "10.0.20348.887",
@@ -12351,7 +12351,7 @@
       "kb_article": "KB5016627",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016627"
     },
     {
       "full_version": "10.0.22000.856",
@@ -12363,7 +12363,7 @@
       "kb_article": "KB5016629",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016629"
     },
     {
       "full_version": "10.0.20348.946",
@@ -12375,7 +12375,7 @@
       "kb_article": "KB5016693",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016693"
     },
     {
       "full_version": "10.0.17763.3346",
@@ -12387,7 +12387,7 @@
       "kb_article": "KB5016690",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016690"
     },
     {
       "full_version": "10.0.17763.3346",
@@ -12399,7 +12399,7 @@
       "kb_article": "KB5016690",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016690"
     },
     {
       "full_version": "10.0.22000.918",
@@ -12411,7 +12411,7 @@
       "kb_article": "KB5016691",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016691"
     },
     {
       "full_version": "10.0.19042.1949",
@@ -12423,7 +12423,7 @@
       "kb_article": "KB5016688",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016688"
     },
     {
       "full_version": "10.0.19043.1949",
@@ -12435,7 +12435,7 @@
       "kb_article": "KB5016688",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016688"
     },
     {
       "full_version": "10.0.19044.1949",
@@ -12447,7 +12447,7 @@
       "kb_article": "KB5016688",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5016688"
     },
     {
       "full_version": "10.0.14393.5356",
@@ -12459,7 +12459,7 @@
       "kb_article": "KB5017305",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017305"
     },
     {
       "full_version": "10.0.14393.5356",
@@ -12471,7 +12471,7 @@
       "kb_article": "KB5017305",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017305"
     },
     {
       "full_version": "10.0.17763.3406",
@@ -12483,7 +12483,7 @@
       "kb_article": "KB5017315",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017315"
     },
     {
       "full_version": "10.0.17763.3406",
@@ -12495,7 +12495,7 @@
       "kb_article": "KB5017315",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017315"
     },
     {
       "full_version": "10.0.19042.2006",
@@ -12507,7 +12507,7 @@
       "kb_article": "KB5017308",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017308"
     },
     {
       "full_version": "10.0.19043.2006",
@@ -12519,7 +12519,7 @@
       "kb_article": "KB5017308",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017308"
     },
     {
       "full_version": "10.0.19044.2006",
@@ -12531,7 +12531,7 @@
       "kb_article": "KB5017308",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017308"
     },
     {
       "full_version": "10.0.20348.1006",
@@ -12543,7 +12543,7 @@
       "kb_article": "KB5017316",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017316"
     },
     {
       "full_version": "10.0.22000.978",
@@ -12555,7 +12555,7 @@
       "kb_article": "KB5017328",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017328"
     },
     {
       "full_version": "10.0.17763.3469",
@@ -12567,7 +12567,7 @@
       "kb_article": "KB5017379",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017379"
     },
     {
       "full_version": "10.0.17763.3469",
@@ -12579,7 +12579,7 @@
       "kb_article": "KB5017379",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017379"
     },
     {
       "full_version": "10.0.19042.2075",
@@ -12591,7 +12591,7 @@
       "kb_article": "KB5017380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017380"
     },
     {
       "full_version": "10.0.19043.2075",
@@ -12603,7 +12603,7 @@
       "kb_article": "KB5017380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017380"
     },
     {
       "full_version": "10.0.19044.2075",
@@ -12615,7 +12615,7 @@
       "kb_article": "KB5017380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017380"
     },
     {
       "full_version": "10.0.20348.1070",
@@ -12627,7 +12627,7 @@
       "kb_article": "KB5017381",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017381"
     },
     {
       "full_version": "10.0.22000.1042",
@@ -12639,7 +12639,7 @@
       "kb_article": "KB5017383",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017383"
     },
     {
       "full_version": "10.0.22621.608",
@@ -12651,7 +12651,7 @@
       "kb_article": "KB5017389",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5017389"
     },
     {
       "full_version": "10.0.14393.5427",
@@ -12663,7 +12663,7 @@
       "kb_article": "KB5018411",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018411"
     },
     {
       "full_version": "10.0.14393.5427",
@@ -12675,7 +12675,7 @@
       "kb_article": "KB5018411",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018411"
     },
     {
       "full_version": "10.0.17763.3532",
@@ -12687,7 +12687,7 @@
       "kb_article": "KB5018419",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018419"
     },
     {
       "full_version": "10.0.17763.3532",
@@ -12699,7 +12699,7 @@
       "kb_article": "KB5018419",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018419"
     },
     {
       "full_version": "10.0.19042.2130",
@@ -12711,7 +12711,7 @@
       "kb_article": "KB5018410",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018410"
     },
     {
       "full_version": "10.0.19043.2130",
@@ -12723,7 +12723,7 @@
       "kb_article": "KB5018410",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018410"
     },
     {
       "full_version": "10.0.19044.2130",
@@ -12735,7 +12735,7 @@
       "kb_article": "KB5018410",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018410"
     },
     {
       "full_version": "10.0.20348.1129",
@@ -12747,7 +12747,7 @@
       "kb_article": "KB5018421",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018421"
     },
     {
       "full_version": "10.0.22000.1098",
@@ -12759,7 +12759,7 @@
       "kb_article": "KB5018418",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018418"
     },
     {
       "full_version": "10.0.22621.674",
@@ -12771,7 +12771,7 @@
       "kb_article": "KB5018427",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018427"
     },
     {
       "full_version": "10.0.17763.3534",
@@ -12783,7 +12783,7 @@
       "kb_article": "KB5020438",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020438"
     },
     {
       "full_version": "10.0.17763.3534",
@@ -12795,7 +12795,7 @@
       "kb_article": "KB5020438",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020438"
     },
     {
       "full_version": "10.0.19042.2132",
@@ -12807,7 +12807,7 @@
       "kb_article": "KB5020435",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020435"
     },
     {
       "full_version": "10.0.19043.2132",
@@ -12819,7 +12819,7 @@
       "kb_article": "KB5020435",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020435"
     },
     {
       "full_version": "10.0.19044.2132",
@@ -12831,7 +12831,7 @@
       "kb_article": "KB5020435",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020435"
     },
     {
       "full_version": "10.0.20348.1131",
@@ -12843,7 +12843,7 @@
       "kb_article": "KB5020436",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020436"
     },
     {
       "full_version": "10.0.22000.1100",
@@ -12855,7 +12855,7 @@
       "kb_article": "KB5020387",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020387"
     },
     {
       "full_version": "10.0.14393.5429",
@@ -12867,7 +12867,7 @@
       "kb_article": "KB5020439",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020439"
     },
     {
       "full_version": "10.0.14393.5429",
@@ -12879,7 +12879,7 @@
       "kb_article": "KB5020439",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020439"
     },
     {
       "full_version": "10.0.22621.675",
@@ -12891,7 +12891,7 @@
       "kb_article": "KB5019509",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019509"
     },
     {
       "full_version": "10.0.19042.2193",
@@ -12903,7 +12903,7 @@
       "kb_article": "KB5018482",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018482"
     },
     {
       "full_version": "10.0.19043.2193",
@@ -12915,7 +12915,7 @@
       "kb_article": "KB5018482",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018482"
     },
     {
       "full_version": "10.0.19044.2193",
@@ -12927,7 +12927,7 @@
       "kb_article": "KB5018482",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018482"
     },
     {
       "full_version": "10.0.20348.1194",
@@ -12939,7 +12939,7 @@
       "kb_article": "KB5018485",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018485"
     },
     {
       "full_version": "10.0.22000.1165",
@@ -12951,7 +12951,7 @@
       "kb_article": "KB5018483",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018483"
     },
     {
       "full_version": "10.0.22621.755",
@@ -12963,7 +12963,7 @@
       "kb_article": "KB5018496",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5018496"
     },
     {
       "full_version": "10.0.19042.2194",
@@ -12975,7 +12975,7 @@
       "kb_article": "KB5020953",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020953"
     },
     {
       "full_version": "10.0.19043.2194",
@@ -12987,7 +12987,7 @@
       "kb_article": "KB5020953",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020953"
     },
     {
       "full_version": "10.0.19044.2194",
@@ -12999,7 +12999,7 @@
       "kb_article": "KB5020953",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020953"
     },
     {
       "full_version": "10.0.19045.2194",
@@ -13011,7 +13011,7 @@
       "kb_article": "KB5020953",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020953"
     },
     {
       "full_version": "10.0.14393.5501",
@@ -13023,7 +13023,7 @@
       "kb_article": "KB5019964",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019964"
     },
     {
       "full_version": "10.0.14393.5501",
@@ -13035,7 +13035,7 @@
       "kb_article": "KB5019964",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019964"
     },
     {
       "full_version": "10.0.17763.3650",
@@ -13047,7 +13047,7 @@
       "kb_article": "KB5019966",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019966"
     },
     {
       "full_version": "10.0.17763.3650",
@@ -13059,7 +13059,7 @@
       "kb_article": "KB5019966",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019966"
     },
     {
       "full_version": "10.0.19042.2251",
@@ -13071,7 +13071,7 @@
       "kb_article": "KB5019959",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019959"
     },
     {
       "full_version": "10.0.19043.2251",
@@ -13083,7 +13083,7 @@
       "kb_article": "KB5019959",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019959"
     },
     {
       "full_version": "10.0.19044.2251",
@@ -13095,7 +13095,7 @@
       "kb_article": "KB5019959",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019959"
     },
     {
       "full_version": "10.0.19045.2251",
@@ -13107,7 +13107,7 @@
       "kb_article": "KB5019959",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019959"
     },
     {
       "full_version": "10.0.20348.1249",
@@ -13119,7 +13119,7 @@
       "kb_article": "KB5019081",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019081"
     },
     {
       "full_version": "10.0.22000.1219",
@@ -13131,7 +13131,7 @@
       "kb_article": "KB5019961",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019961"
     },
     {
       "full_version": "10.0.22621.819",
@@ -13143,7 +13143,7 @@
       "kb_article": "KB5019980",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019980"
     },
     {
       "full_version": "10.0.19042.2311",
@@ -13155,7 +13155,7 @@
       "kb_article": "KB5020030",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020030"
     },
     {
       "full_version": "10.0.19043.2311",
@@ -13167,7 +13167,7 @@
       "kb_article": "KB5020030",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020030"
     },
     {
       "full_version": "10.0.19044.2311",
@@ -13179,7 +13179,7 @@
       "kb_article": "KB5020030",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020030"
     },
     {
       "full_version": "10.0.19045.2311",
@@ -13191,7 +13191,7 @@
       "kb_article": "KB5020030",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020030"
     },
     {
       "full_version": "10.0.22000.1281",
@@ -13203,7 +13203,7 @@
       "kb_article": "KB5019157",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019157"
     },
     {
       "full_version": "10.0.14393.5502",
@@ -13215,7 +13215,7 @@
       "kb_article": "KB5021654",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021654"
     },
     {
       "full_version": "10.0.14393.5502",
@@ -13227,7 +13227,7 @@
       "kb_article": "KB5021654",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021654"
     },
     {
       "full_version": "10.0.17763.3653",
@@ -13239,7 +13239,7 @@
       "kb_article": "KB5021655",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021655"
     },
     {
       "full_version": "10.0.17763.3653",
@@ -13251,7 +13251,7 @@
       "kb_article": "KB5021655",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021655"
     },
     {
       "full_version": "10.0.20348.1251",
@@ -13263,7 +13263,7 @@
       "kb_article": "KB5021656",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021656"
     },
     {
       "full_version": "10.0.20348.1311",
@@ -13275,7 +13275,7 @@
       "kb_article": "KB5020032",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020032"
     },
     {
       "full_version": "10.0.22621.900",
@@ -13287,7 +13287,7 @@
       "kb_article": "KB5020044",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5020044"
     },
     {
       "full_version": "10.0.14393.5582",
@@ -13299,7 +13299,7 @@
       "kb_article": "KB5021235",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021235"
     },
     {
       "full_version": "10.0.14393.5582",
@@ -13311,7 +13311,7 @@
       "kb_article": "KB5021235",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021235"
     },
     {
       "full_version": "10.0.17763.3770",
@@ -13323,7 +13323,7 @@
       "kb_article": "KB5021237",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021237"
     },
     {
       "full_version": "10.0.17763.3770",
@@ -13335,7 +13335,7 @@
       "kb_article": "KB5021237",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021237"
     },
     {
       "full_version": "10.0.19042.2364",
@@ -13347,7 +13347,7 @@
       "kb_article": "KB5021233",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021233"
     },
     {
       "full_version": "10.0.19043.2364",
@@ -13359,7 +13359,7 @@
       "kb_article": "KB5021233",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021233"
     },
     {
       "full_version": "10.0.19044.2364",
@@ -13371,7 +13371,7 @@
       "kb_article": "KB5021233",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021233"
     },
     {
       "full_version": "10.0.19045.2364",
@@ -13383,7 +13383,7 @@
       "kb_article": "KB5021233",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021233"
     },
     {
       "full_version": "10.0.20348.1366",
@@ -13395,7 +13395,7 @@
       "kb_article": "KB5021249",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021249"
     },
     {
       "full_version": "10.0.22000.1335",
@@ -13407,7 +13407,7 @@
       "kb_article": "KB5021234",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021234"
     },
     {
       "full_version": "10.0.22621.963",
@@ -13419,7 +13419,7 @@
       "kb_article": "KB5021255",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5021255"
     },
     {
       "full_version": "10.0.17763.3772",
@@ -13431,7 +13431,7 @@
       "kb_article": "KB5022554",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022554"
     },
     {
       "full_version": "10.0.17763.3772",
@@ -13443,7 +13443,7 @@
       "kb_article": "KB5022554",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022554"
     },
     {
       "full_version": "10.0.20348.1368",
@@ -13455,7 +13455,7 @@
       "kb_article": "KB5022553",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022553"
     },
     {
       "full_version": "10.0.14393.5648",
@@ -13467,7 +13467,7 @@
       "kb_article": "KB5022289",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022289"
     },
     {
       "full_version": "10.0.14393.5648",
@@ -13479,7 +13479,7 @@
       "kb_article": "KB5022289",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022289"
     },
     {
       "full_version": "10.0.17763.3887",
@@ -13491,7 +13491,7 @@
       "kb_article": "KB5022286",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022286"
     },
     {
       "full_version": "10.0.17763.3887",
@@ -13503,7 +13503,7 @@
       "kb_article": "KB5022286",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022286"
     },
     {
       "full_version": "10.0.19042.2486",
@@ -13515,7 +13515,7 @@
       "kb_article": "KB5022282",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022282"
     },
     {
       "full_version": "10.0.19044.2486",
@@ -13527,7 +13527,7 @@
       "kb_article": "KB5022282",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022282"
     },
     {
       "full_version": "10.0.19045.2486",
@@ -13539,7 +13539,7 @@
       "kb_article": "KB5022282",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022282"
     },
     {
       "full_version": "10.0.20348.1487",
@@ -13551,7 +13551,7 @@
       "kb_article": "KB5022291",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022291"
     },
     {
       "full_version": "10.0.22000.1455",
@@ -13563,7 +13563,7 @@
       "kb_article": "KB5022287",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022287"
     },
     {
       "full_version": "10.0.22621.1105",
@@ -13575,7 +13575,7 @@
       "kb_article": "KB5022303",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022303"
     },
     {
       "full_version": "10.0.19042.2546",
@@ -13587,7 +13587,7 @@
       "kb_article": "KB5019275",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019275"
     },
     {
       "full_version": "10.0.19044.2546",
@@ -13599,7 +13599,7 @@
       "kb_article": "KB5019275",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019275"
     },
     {
       "full_version": "10.0.19045.2546",
@@ -13611,7 +13611,7 @@
       "kb_article": "KB5019275",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019275"
     },
     {
       "full_version": "10.0.22000.1516",
@@ -13623,7 +13623,7 @@
       "kb_article": "KB5019274",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5019274"
     },
     {
       "full_version": "10.0.22621.1194",
@@ -13635,7 +13635,7 @@
       "kb_article": "KB5022360",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022360"
     },
     {
       "full_version": "10.0.14393.5717",
@@ -13647,7 +13647,7 @@
       "kb_article": "KB5022838",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022838"
     },
     {
       "full_version": "10.0.14393.5717",
@@ -13659,7 +13659,7 @@
       "kb_article": "KB5022838",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022838"
     },
     {
       "full_version": "10.0.17763.4010",
@@ -13671,7 +13671,7 @@
       "kb_article": "KB5022840",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022840"
     },
     {
       "full_version": "10.0.17763.4010",
@@ -13683,7 +13683,7 @@
       "kb_article": "KB5022840",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022840"
     },
     {
       "full_version": "10.0.19042.2604",
@@ -13695,7 +13695,7 @@
       "kb_article": "KB5022834",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022834"
     },
     {
       "full_version": "10.0.19044.2604",
@@ -13707,7 +13707,7 @@
       "kb_article": "KB5022834",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022834"
     },
     {
       "full_version": "10.0.19045.2604",
@@ -13719,7 +13719,7 @@
       "kb_article": "KB5022834",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022834"
     },
     {
       "full_version": "10.0.20348.1547",
@@ -13731,7 +13731,7 @@
       "kb_article": "KB5022842",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022842"
     },
     {
       "full_version": "10.0.22000.1574",
@@ -13743,7 +13743,7 @@
       "kb_article": "KB5022836",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022836"
     },
     {
       "full_version": "10.0.22621.1265",
@@ -13755,7 +13755,7 @@
       "kb_article": "KB5022845",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022845"
     },
     {
       "full_version": "10.0.19042.2673",
@@ -13767,7 +13767,7 @@
       "kb_article": "KB5022906",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022906"
     },
     {
       "full_version": "10.0.19044.2673",
@@ -13779,7 +13779,7 @@
       "kb_article": "KB5022906",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022906"
     },
     {
       "full_version": "10.0.19045.2673",
@@ -13791,7 +13791,7 @@
       "kb_article": "KB5022906",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022906"
     },
     {
       "full_version": "10.0.22000.1641",
@@ -13803,7 +13803,7 @@
       "kb_article": "KB5022905",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022905"
     },
     {
       "full_version": "10.0.22621.1344",
@@ -13815,7 +13815,7 @@
       "kb_article": "KB5022913",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5022913"
     },
     {
       "full_version": "10.0.14393.5786",
@@ -13827,7 +13827,7 @@
       "kb_article": "KB5023697",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023697"
     },
     {
       "full_version": "10.0.14393.5786",
@@ -13839,7 +13839,7 @@
       "kb_article": "KB5023697",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023697"
     },
     {
       "full_version": "10.0.17763.4131",
@@ -13851,7 +13851,7 @@
       "kb_article": "KB5023702",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023702"
     },
     {
       "full_version": "10.0.17763.4131",
@@ -13863,7 +13863,7 @@
       "kb_article": "KB5023702",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023702"
     },
     {
       "full_version": "10.0.19042.2728",
@@ -13875,7 +13875,7 @@
       "kb_article": "KB5023696",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023696"
     },
     {
       "full_version": "10.0.19044.2728",
@@ -13887,7 +13887,7 @@
       "kb_article": "KB5023696",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023696"
     },
     {
       "full_version": "10.0.19045.2728",
@@ -13899,7 +13899,7 @@
       "kb_article": "KB5023696",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023696"
     },
     {
       "full_version": "10.0.20348.1607",
@@ -13911,7 +13911,7 @@
       "kb_article": "KB5023705",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023705"
     },
     {
       "full_version": "10.0.22000.1696",
@@ -13923,7 +13923,7 @@
       "kb_article": "KB5023698",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023698"
     },
     {
       "full_version": "10.0.22621.1413",
@@ -13935,7 +13935,7 @@
       "kb_article": "KB5023706",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023706"
     },
     {
       "full_version": "10.0.19042.2788",
@@ -13947,7 +13947,7 @@
       "kb_article": "KB5023773",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023773"
     },
     {
       "full_version": "10.0.19044.2788",
@@ -13959,7 +13959,7 @@
       "kb_article": "KB5023773",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023773"
     },
     {
       "full_version": "10.0.19045.2788",
@@ -13971,7 +13971,7 @@
       "kb_article": "KB5023773",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023773"
     },
     {
       "full_version": "10.0.22000.1761",
@@ -13983,7 +13983,7 @@
       "kb_article": "KB5023774",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023774"
     },
     {
       "full_version": "10.0.22621.1485",
@@ -13995,7 +13995,7 @@
       "kb_article": "KB5023778",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5023778"
     },
     {
       "full_version": "10.0.14393.5850",
@@ -14007,7 +14007,7 @@
       "kb_article": "KB5025228",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025228"
     },
     {
       "full_version": "10.0.14393.5850",
@@ -14019,7 +14019,7 @@
       "kb_article": "KB5025228",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025228"
     },
     {
       "full_version": "10.0.17763.4252",
@@ -14031,7 +14031,7 @@
       "kb_article": "KB5025229",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025229"
     },
     {
       "full_version": "10.0.17763.4252",
@@ -14043,7 +14043,7 @@
       "kb_article": "KB5025229",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025229"
     },
     {
       "full_version": "10.0.19042.2846",
@@ -14055,7 +14055,7 @@
       "kb_article": "KB5025221",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025221"
     },
     {
       "full_version": "10.0.19044.2846",
@@ -14067,7 +14067,7 @@
       "kb_article": "KB5025221",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025221"
     },
     {
       "full_version": "10.0.19045.2846",
@@ -14079,7 +14079,7 @@
       "kb_article": "KB5025221",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025221"
     },
     {
       "full_version": "10.0.20348.1668",
@@ -14091,7 +14091,7 @@
       "kb_article": "KB5025230",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025230"
     },
     {
       "full_version": "10.0.22000.1817",
@@ -14103,7 +14103,7 @@
       "kb_article": "KB5025224",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025224"
     },
     {
       "full_version": "10.0.22621.1555",
@@ -14115,7 +14115,7 @@
       "kb_article": "KB5025239",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025239"
     },
     {
       "full_version": "10.0.19045.2913",
@@ -14127,7 +14127,7 @@
       "kb_article": "KB5025297",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025297"
     },
     {
       "full_version": "10.0.22000.1880",
@@ -14139,7 +14139,7 @@
       "kb_article": "KB5025298",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025298"
     },
     {
       "full_version": "10.0.22621.1635",
@@ -14151,7 +14151,7 @@
       "kb_article": "KB5025305",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5025305"
     },
     {
       "full_version": "10.0.14393.5921",
@@ -14163,7 +14163,7 @@
       "kb_article": "KB5026363",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026363"
     },
     {
       "full_version": "10.0.14393.5921",
@@ -14175,7 +14175,7 @@
       "kb_article": "KB5026363",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026363"
     },
     {
       "full_version": "10.0.17763.4377",
@@ -14187,7 +14187,7 @@
       "kb_article": "KB5026362",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026362"
     },
     {
       "full_version": "10.0.17763.4377",
@@ -14199,7 +14199,7 @@
       "kb_article": "KB5026362",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026362"
     },
     {
       "full_version": "10.0.19042.2965",
@@ -14211,7 +14211,7 @@
       "kb_article": "KB5026361",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026361"
     },
     {
       "full_version": "10.0.19044.2965",
@@ -14223,7 +14223,7 @@
       "kb_article": "KB5026361",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026361"
     },
     {
       "full_version": "10.0.19045.2965",
@@ -14235,7 +14235,7 @@
       "kb_article": "KB5026361",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026361"
     },
     {
       "full_version": "10.0.20348.1726",
@@ -14247,7 +14247,7 @@
       "kb_article": "KB5026370",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026370"
     },
     {
       "full_version": "10.0.22000.1936",
@@ -14259,7 +14259,7 @@
       "kb_article": "KB5026368",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026368"
     },
     {
       "full_version": "10.0.22621.1702",
@@ -14271,7 +14271,7 @@
       "kb_article": "KB5026372",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026372"
     },
     {
       "full_version": "10.0.19045.3031",
@@ -14283,7 +14283,7 @@
       "kb_article": "KB5026435",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026435"
     },
     {
       "full_version": "10.0.22000.2003",
@@ -14295,7 +14295,7 @@
       "kb_article": "KB5026436",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026436"
     },
     {
       "full_version": "10.0.22621.1778",
@@ -14307,7 +14307,7 @@
       "kb_article": "KB5026446",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5026446"
     },
     {
       "full_version": "10.0.14393.5989",
@@ -14319,7 +14319,7 @@
       "kb_article": "KB5027219",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027219"
     },
     {
       "full_version": "10.0.14393.5989",
@@ -14331,7 +14331,7 @@
       "kb_article": "KB5027219",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027219"
     },
     {
       "full_version": "10.0.17763.4499",
@@ -14343,7 +14343,7 @@
       "kb_article": "KB5027222",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027222"
     },
     {
       "full_version": "10.0.17763.4499",
@@ -14355,7 +14355,7 @@
       "kb_article": "KB5027222",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027222"
     },
     {
       "full_version": "10.0.19044.3086",
@@ -14367,7 +14367,7 @@
       "kb_article": "KB5027215",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027215"
     },
     {
       "full_version": "10.0.19045.3086",
@@ -14379,7 +14379,7 @@
       "kb_article": "KB5027215",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027215"
     },
     {
       "full_version": "10.0.20348.1787",
@@ -14391,7 +14391,7 @@
       "kb_article": "KB5027225",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027225"
     },
     {
       "full_version": "10.0.22000.2057",
@@ -14403,7 +14403,7 @@
       "kb_article": "KB5027223",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027223"
     },
     {
       "full_version": "10.0.22621.1848",
@@ -14415,7 +14415,7 @@
       "kb_article": "KB5027231",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027231"
     },
     {
       "full_version": "10.0.14393.5996",
@@ -14427,7 +14427,7 @@
       "kb_article": "KB5028623",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028623"
     },
     {
       "full_version": "10.0.14393.5996",
@@ -14439,7 +14439,7 @@
       "kb_article": "KB5028623",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028623"
     },
     {
       "full_version": "10.0.19045.3155",
@@ -14451,7 +14451,7 @@
       "kb_article": "KB5027293",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027293"
     },
     {
       "full_version": "10.0.22621.1928",
@@ -14463,7 +14463,7 @@
       "kb_article": "KB5027303",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027303"
     },
     {
       "full_version": "10.0.22000.2124",
@@ -14475,7 +14475,7 @@
       "kb_article": "KB5027292",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5027292"
     },
     {
       "full_version": "10.0.14393.6085",
@@ -14487,7 +14487,7 @@
       "kb_article": "KB5028169",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028169"
     },
     {
       "full_version": "10.0.14393.6085",
@@ -14499,7 +14499,7 @@
       "kb_article": "KB5028169",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028169"
     },
     {
       "full_version": "10.0.17763.4645",
@@ -14511,7 +14511,7 @@
       "kb_article": "KB5028168",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028168"
     },
     {
       "full_version": "10.0.17763.4645",
@@ -14523,7 +14523,7 @@
       "kb_article": "KB5028168",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028168"
     },
     {
       "full_version": "10.0.19044.3208",
@@ -14535,7 +14535,7 @@
       "kb_article": "KB5028166",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028166"
     },
     {
       "full_version": "10.0.19045.3208",
@@ -14547,7 +14547,7 @@
       "kb_article": "KB5028166",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028166"
     },
     {
       "full_version": "10.0.20348.1850",
@@ -14559,7 +14559,7 @@
       "kb_article": "KB5028171",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028171"
     },
     {
       "full_version": "10.0.22000.2176",
@@ -14571,7 +14571,7 @@
       "kb_article": "KB5028182",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028182"
     },
     {
       "full_version": "10.0.22621.1992",
@@ -14583,7 +14583,7 @@
       "kb_article": "KB5028185",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028185"
     },
     {
       "full_version": "10.0.19045.3271",
@@ -14595,7 +14595,7 @@
       "kb_article": "KB5028244",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028244"
     },
     {
       "full_version": "10.0.22000.2245",
@@ -14607,7 +14607,7 @@
       "kb_article": "KB5028245",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028245"
     },
     {
       "full_version": "10.0.22621.2070",
@@ -14619,7 +14619,7 @@
       "kb_article": "KB5028254",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5028254"
     },
     {
       "full_version": "10.0.14393.6167",
@@ -14631,7 +14631,7 @@
       "kb_article": "KB5029242",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029242"
     },
     {
       "full_version": "10.0.14393.6167",
@@ -14643,7 +14643,7 @@
       "kb_article": "KB5029242",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029242"
     },
     {
       "full_version": "10.0.17763.4737",
@@ -14655,7 +14655,7 @@
       "kb_article": "KB5029247",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029247"
     },
     {
       "full_version": "10.0.17763.4737",
@@ -14667,7 +14667,7 @@
       "kb_article": "KB5029247",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029247"
     },
     {
       "full_version": "10.0.19044.3324",
@@ -14679,7 +14679,7 @@
       "kb_article": "KB5029244",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029244"
     },
     {
       "full_version": "10.0.19045.3324",
@@ -14691,7 +14691,7 @@
       "kb_article": "KB5029244",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029244"
     },
     {
       "full_version": "10.0.20348.1906",
@@ -14703,7 +14703,7 @@
       "kb_article": "KB5029250",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029250"
     },
     {
       "full_version": "10.0.22000.2295",
@@ -14715,7 +14715,7 @@
       "kb_article": "KB5029253",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029253"
     },
     {
       "full_version": "10.0.22621.2134",
@@ -14727,7 +14727,7 @@
       "kb_article": "KB5029263",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029263"
     },
     {
       "full_version": "10.0.19045.3393",
@@ -14739,7 +14739,7 @@
       "kb_article": "KB5029331",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029331"
     },
     {
       "full_version": "10.0.22000.2360",
@@ -14751,7 +14751,7 @@
       "kb_article": "KB5029332",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029332"
     },
     {
       "full_version": "10.0.22621.2215",
@@ -14763,7 +14763,7 @@
       "kb_article": "KB5029351",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5029351"
     },
     {
       "full_version": "10.0.14393.6252",
@@ -14775,7 +14775,7 @@
       "kb_article": "KB5030213",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030213"
     },
     {
       "full_version": "10.0.14393.6252",
@@ -14787,7 +14787,7 @@
       "kb_article": "KB5030213",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030213"
     },
     {
       "full_version": "10.0.17763.4851",
@@ -14799,7 +14799,7 @@
       "kb_article": "KB5030214",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030214"
     },
     {
       "full_version": "10.0.17763.4851",
@@ -14811,7 +14811,7 @@
       "kb_article": "KB5030214",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030214"
     },
     {
       "full_version": "10.0.19044.3448",
@@ -14823,7 +14823,7 @@
       "kb_article": "KB5030211",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030211"
     },
     {
       "full_version": "10.0.19045.3448",
@@ -14835,7 +14835,7 @@
       "kb_article": "KB5030211",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030211"
     },
     {
       "full_version": "10.0.20348.1970",
@@ -14847,7 +14847,7 @@
       "kb_article": "KB5030216",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030216"
     },
     {
       "full_version": "10.0.22000.2416",
@@ -14859,7 +14859,7 @@
       "kb_article": "KB5030217",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030217"
     },
     {
       "full_version": "10.0.22621.2283",
@@ -14871,7 +14871,7 @@
       "kb_article": "KB5030219",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030219"
     },
     {
       "full_version": "10.0.19045.3516",
@@ -14883,7 +14883,7 @@
       "kb_article": "KB5030300",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030300"
     },
     {
       "full_version": "10.0.22000.2482",
@@ -14895,7 +14895,7 @@
       "kb_article": "KB5030301",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030301"
     },
     {
       "full_version": "10.0.22621.2361",
@@ -14907,7 +14907,7 @@
       "kb_article": "KB5030310",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5030310"
     },
     {
       "full_version": "10.0.14393.6351",
@@ -14919,7 +14919,7 @@
       "kb_article": "KB5031362",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031362"
     },
     {
       "full_version": "10.0.14393.6351",
@@ -14931,7 +14931,7 @@
       "kb_article": "KB5031362",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031362"
     },
     {
       "full_version": "10.0.17763.4974",
@@ -14943,7 +14943,7 @@
       "kb_article": "KB5031361",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031361"
     },
     {
       "full_version": "10.0.17763.4974",
@@ -14955,7 +14955,7 @@
       "kb_article": "KB5031361",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031361"
     },
     {
       "full_version": "10.0.19044.3570",
@@ -14967,7 +14967,7 @@
       "kb_article": "KB5031356",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031356"
     },
     {
       "full_version": "10.0.19045.3570",
@@ -14979,7 +14979,7 @@
       "kb_article": "KB5031356",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031356"
     },
     {
       "full_version": "10.0.20348.2031",
@@ -14991,7 +14991,7 @@
       "kb_article": "KB5031364",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031364"
     },
     {
       "full_version": "10.0.22000.2538",
@@ -15003,7 +15003,7 @@
       "kb_article": "KB5031358",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031358"
     },
     {
       "full_version": "10.0.22621.2428",
@@ -15015,7 +15015,7 @@
       "kb_article": "KB5031354",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031354"
     },
     {
       "full_version": "10.0.19045.3636",
@@ -15027,7 +15027,7 @@
       "kb_article": "KB5031445",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031445"
     },
     {
       "full_version": "10.0.22621.2506",
@@ -15039,7 +15039,7 @@
       "kb_article": "KB5031455",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031455"
     },
     {
       "full_version": "10.0.22631.2506",
@@ -15051,7 +15051,7 @@
       "kb_article": "KB5031455",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5031455"
     },
     {
       "full_version": "10.0.14393.6452",
@@ -15063,7 +15063,7 @@
       "kb_article": "KB5032197",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032197"
     },
     {
       "full_version": "10.0.14393.6452",
@@ -15075,7 +15075,7 @@
       "kb_article": "KB5032197",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032197"
     },
     {
       "full_version": "10.0.17763.5122",
@@ -15087,7 +15087,7 @@
       "kb_article": "KB5032196",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032196"
     },
     {
       "full_version": "10.0.17763.5122",
@@ -15099,7 +15099,7 @@
       "kb_article": "KB5032196",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032196"
     },
     {
       "full_version": "10.0.19044.3693",
@@ -15111,7 +15111,7 @@
       "kb_article": "KB5032189",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032189"
     },
     {
       "full_version": "10.0.19045.3693",
@@ -15123,7 +15123,7 @@
       "kb_article": "KB5032189",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032189"
     },
     {
       "full_version": "10.0.20348.2113",
@@ -15135,7 +15135,7 @@
       "kb_article": "KB5032198",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032198"
     },
     {
       "full_version": "10.0.22000.2600",
@@ -15147,7 +15147,7 @@
       "kb_article": "KB5032192",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032192"
     },
     {
       "full_version": "10.0.22621.2715",
@@ -15159,7 +15159,7 @@
       "kb_article": "KB5032190",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032190"
     },
     {
       "full_version": "10.0.22631.2715",
@@ -15171,7 +15171,7 @@
       "kb_article": "KB5032190",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032190"
     },
     {
       "full_version": "10.0.25398.531",
@@ -15183,7 +15183,7 @@
       "kb_article": "KB5032202",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032202"
     },
     {
       "full_version": "10.0.19045.3758",
@@ -15195,7 +15195,7 @@
       "kb_article": "KB5032278",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032278"
     },
     {
       "full_version": "10.0.22621.2792",
@@ -15207,7 +15207,7 @@
       "kb_article": "KB5032288",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032288"
     },
     {
       "full_version": "10.0.22631.2792",
@@ -15219,7 +15219,7 @@
       "kb_article": "KB5032288",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5032288"
     },
     {
       "full_version": "10.0.14393.6529",
@@ -15231,7 +15231,7 @@
       "kb_article": "KB5033373",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033373"
     },
     {
       "full_version": "10.0.14393.6529",
@@ -15243,7 +15243,7 @@
       "kb_article": "KB5033373",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033373"
     },
     {
       "full_version": "10.0.17763.5206",
@@ -15255,7 +15255,7 @@
       "kb_article": "KB5033371",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033371"
     },
     {
       "full_version": "10.0.17763.5206",
@@ -15267,7 +15267,7 @@
       "kb_article": "KB5033371",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033371"
     },
     {
       "full_version": "10.0.19044.3803",
@@ -15279,7 +15279,7 @@
       "kb_article": "KB5033372",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033372"
     },
     {
       "full_version": "10.0.19045.3803",
@@ -15291,7 +15291,7 @@
       "kb_article": "KB5033372",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033372"
     },
     {
       "full_version": "10.0.20348.2159",
@@ -15303,7 +15303,7 @@
       "kb_article": "KB5033118",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033118"
     },
     {
       "full_version": "10.0.22000.2652",
@@ -15315,7 +15315,7 @@
       "kb_article": "KB5033369",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033369"
     },
     {
       "full_version": "10.0.22621.2861",
@@ -15327,7 +15327,7 @@
       "kb_article": "KB5033375",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033375"
     },
     {
       "full_version": "10.0.22631.2861",
@@ -15339,7 +15339,7 @@
       "kb_article": "KB5033375",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033375"
     },
     {
       "full_version": "10.0.25398.584",
@@ -15351,7 +15351,7 @@
       "kb_article": "KB5033383",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5033383"
     },
     {
       "full_version": "10.0.14393.6614",
@@ -15363,7 +15363,7 @@
       "kb_article": "KB5034119",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034119"
     },
     {
       "full_version": "10.0.14393.6614",
@@ -15375,7 +15375,7 @@
       "kb_article": "KB5034119",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034119"
     },
     {
       "full_version": "10.0.17763.5329",
@@ -15387,7 +15387,7 @@
       "kb_article": "KB5034127",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034127"
     },
     {
       "full_version": "10.0.17763.5329",
@@ -15399,7 +15399,7 @@
       "kb_article": "KB5034127",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034127"
     },
     {
       "full_version": "10.0.19044.3930",
@@ -15411,7 +15411,7 @@
       "kb_article": "KB5034122",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034122"
     },
     {
       "full_version": "10.0.19045.3930",
@@ -15423,7 +15423,7 @@
       "kb_article": "KB5034122",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034122"
     },
     {
       "full_version": "10.0.20348.2227",
@@ -15435,7 +15435,7 @@
       "kb_article": "KB5034129",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034129"
     },
     {
       "full_version": "10.0.22000.2713",
@@ -15447,7 +15447,7 @@
       "kb_article": "KB5034121",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034121"
     },
     {
       "full_version": "10.0.22621.3007",
@@ -15459,7 +15459,7 @@
       "kb_article": "KB5034123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034123"
     },
     {
       "full_version": "10.0.22631.3007",
@@ -15471,7 +15471,7 @@
       "kb_article": "KB5034123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034123"
     },
     {
       "full_version": "10.0.25398.643",
@@ -15483,7 +15483,7 @@
       "kb_article": "KB5034130",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034130"
     },
     {
       "full_version": "10.0.19045.3996",
@@ -15495,7 +15495,7 @@
       "kb_article": "KB5034203",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034203"
     },
     {
       "full_version": "10.0.22621.3085",
@@ -15507,7 +15507,7 @@
       "kb_article": "KB5034204",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034204"
     },
     {
       "full_version": "10.0.22631.3085",
@@ -15519,7 +15519,7 @@
       "kb_article": "KB5034204",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034204"
     },
     {
       "full_version": "10.0.14393.6709",
@@ -15531,7 +15531,7 @@
       "kb_article": "KB5034767",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034767"
     },
     {
       "full_version": "10.0.14393.6709",
@@ -15543,7 +15543,7 @@
       "kb_article": "KB5034767",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034767"
     },
     {
       "full_version": "10.0.17763.5458",
@@ -15555,7 +15555,7 @@
       "kb_article": "KB5034768",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034768"
     },
     {
       "full_version": "10.0.17763.5458",
@@ -15567,7 +15567,7 @@
       "kb_article": "KB5034768",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034768"
     },
     {
       "full_version": "10.0.19044.4046",
@@ -15579,7 +15579,7 @@
       "kb_article": "KB5034763",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034763"
     },
     {
       "full_version": "10.0.19045.4046",
@@ -15591,7 +15591,7 @@
       "kb_article": "KB5034763",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034763"
     },
     {
       "full_version": "10.0.20348.2322",
@@ -15603,7 +15603,7 @@
       "kb_article": "KB5034770",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034770"
     },
     {
       "full_version": "10.0.22000.2777",
@@ -15615,7 +15615,7 @@
       "kb_article": "KB5034766",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034766"
     },
     {
       "full_version": "10.0.22621.3155",
@@ -15627,7 +15627,7 @@
       "kb_article": "KB5034765",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034765"
     },
     {
       "full_version": "10.0.22631.3155",
@@ -15639,7 +15639,7 @@
       "kb_article": "KB5034765",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034765"
     },
     {
       "full_version": "10.0.25398.709",
@@ -15651,7 +15651,7 @@
       "kb_article": "KB5034769",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034769"
     },
     {
       "full_version": "10.0.19045.4123",
@@ -15663,7 +15663,7 @@
       "kb_article": "KB5034843",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034843"
     },
     {
       "full_version": "10.0.22621.3235",
@@ -15675,7 +15675,7 @@
       "kb_article": "KB5034848",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034848"
     },
     {
       "full_version": "10.0.22631.3235",
@@ -15687,7 +15687,7 @@
       "kb_article": "KB5034848",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5034848"
     },
     {
       "full_version": "10.0.14393.6796",
@@ -15699,7 +15699,7 @@
       "kb_article": "KB5035855",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035855"
     },
     {
       "full_version": "10.0.14393.6796",
@@ -15711,7 +15711,7 @@
       "kb_article": "KB5035855",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035855"
     },
     {
       "full_version": "10.0.17763.5576",
@@ -15723,7 +15723,7 @@
       "kb_article": "KB5035849",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035849"
     },
     {
       "full_version": "10.0.17763.5576",
@@ -15735,7 +15735,7 @@
       "kb_article": "KB5035849",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035849"
     },
     {
       "full_version": "10.0.19044.4170",
@@ -15747,7 +15747,7 @@
       "kb_article": "KB5035845",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035845"
     },
     {
       "full_version": "10.0.19045.4170",
@@ -15759,7 +15759,7 @@
       "kb_article": "KB5035845",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035845"
     },
     {
       "full_version": "10.0.20348.2340",
@@ -15771,7 +15771,7 @@
       "kb_article": "KB5035857",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035857"
     },
     {
       "full_version": "10.0.22000.2836",
@@ -15783,7 +15783,7 @@
       "kb_article": "KB5035854",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035854"
     },
     {
       "full_version": "10.0.22621.3296",
@@ -15795,7 +15795,7 @@
       "kb_article": "KB5035853",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035853"
     },
     {
       "full_version": "10.0.22631.3296",
@@ -15807,7 +15807,7 @@
       "kb_article": "KB5035853",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035853"
     },
     {
       "full_version": "10.0.25398.763",
@@ -15819,7 +15819,7 @@
       "kb_article": "KB5035856",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035856"
     },
     {
       "full_version": "10.0.14393.6799",
@@ -15831,7 +15831,7 @@
       "kb_article": "KB5037423",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037423"
     },
     {
       "full_version": "10.0.14393.6799",
@@ -15843,7 +15843,7 @@
       "kb_article": "KB5037423",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037423"
     },
     {
       "full_version": "10.0.20348.2342",
@@ -15855,7 +15855,7 @@
       "kb_article": "KB5037422",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037422"
     },
     {
       "full_version": "10.0.17763.5579",
@@ -15867,7 +15867,7 @@
       "kb_article": "KB5037425",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037425"
     },
     {
       "full_version": "10.0.17763.5579",
@@ -15879,7 +15879,7 @@
       "kb_article": "KB5037425",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037425"
     },
     {
       "full_version": "10.0.19045.4239",
@@ -15891,7 +15891,7 @@
       "kb_article": "KB5035941",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035941"
     },
     {
       "full_version": "10.0.22621.3374",
@@ -15903,7 +15903,7 @@
       "kb_article": "KB5035942",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035942"
     },
     {
       "full_version": "10.0.22631.3374",
@@ -15915,7 +15915,7 @@
       "kb_article": "KB5035942",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5035942"
     },
     {
       "full_version": "10.0.14393.6897",
@@ -15927,7 +15927,7 @@
       "kb_article": "KB5036899",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036899"
     },
     {
       "full_version": "10.0.14393.6897",
@@ -15939,7 +15939,7 @@
       "kb_article": "KB5036899",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036899"
     },
     {
       "full_version": "10.0.17763.5696",
@@ -15951,7 +15951,7 @@
       "kb_article": "KB5036896",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036896"
     },
     {
       "full_version": "10.0.17763.5696",
@@ -15963,7 +15963,7 @@
       "kb_article": "KB5036896",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036896"
     },
     {
       "full_version": "10.0.19044.4291",
@@ -15975,7 +15975,7 @@
       "kb_article": "KB5036892",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036892"
     },
     {
       "full_version": "10.0.19045.4291",
@@ -15987,7 +15987,7 @@
       "kb_article": "KB5036892",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036892"
     },
     {
       "full_version": "10.0.20348.2402",
@@ -15999,7 +15999,7 @@
       "kb_article": "KB5036909",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036909"
     },
     {
       "full_version": "10.0.22000.2899",
@@ -16011,7 +16011,7 @@
       "kb_article": "KB5036894",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036894"
     },
     {
       "full_version": "10.0.22621.3447",
@@ -16023,7 +16023,7 @@
       "kb_article": "KB5036893",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036893"
     },
     {
       "full_version": "10.0.22631.3447",
@@ -16035,7 +16035,7 @@
       "kb_article": "KB5036893",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036893"
     },
     {
       "full_version": "10.0.25398.830",
@@ -16047,7 +16047,7 @@
       "kb_article": "KB5036910",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036910"
     },
     {
       "full_version": "10.0.19045.4355",
@@ -16059,7 +16059,7 @@
       "kb_article": "KB5036979",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036979"
     },
     {
       "full_version": "10.0.22621.3527",
@@ -16071,7 +16071,7 @@
       "kb_article": "KB5036980",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036980"
     },
     {
       "full_version": "10.0.22631.3527",
@@ -16083,7 +16083,7 @@
       "kb_article": "KB5036980",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5036980"
     },
     {
       "full_version": "10.0.14393.6981",
@@ -16095,7 +16095,7 @@
       "kb_article": "KB5037763",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037763"
     },
     {
       "full_version": "10.0.14393.6981",
@@ -16107,7 +16107,7 @@
       "kb_article": "KB5037763",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037763"
     },
     {
       "full_version": "10.0.17763.5820",
@@ -16119,7 +16119,7 @@
       "kb_article": "KB5037765",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037765"
     },
     {
       "full_version": "10.0.17763.5820",
@@ -16131,7 +16131,7 @@
       "kb_article": "KB5037765",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037765"
     },
     {
       "full_version": "10.0.19044.4412",
@@ -16143,7 +16143,7 @@
       "kb_article": "KB5037768",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037768"
     },
     {
       "full_version": "10.0.19045.4412",
@@ -16155,7 +16155,7 @@
       "kb_article": "KB5037768",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037768"
     },
     {
       "full_version": "10.0.20348.2461",
@@ -16167,7 +16167,7 @@
       "kb_article": "KB5037782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037782"
     },
     {
       "full_version": "10.0.22000.2960",
@@ -16179,7 +16179,7 @@
       "kb_article": "KB5037770",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037770"
     },
     {
       "full_version": "10.0.22621.3593",
@@ -16191,7 +16191,7 @@
       "kb_article": "KB5037771",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037771"
     },
     {
       "full_version": "10.0.22631.3593",
@@ -16203,7 +16203,7 @@
       "kb_article": "KB5037771",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037771"
     },
     {
       "full_version": "10.0.25398.887",
@@ -16215,7 +16215,7 @@
       "kb_article": "KB5037781",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037781"
     },
     {
       "full_version": "10.0.17763.5830",
@@ -16227,7 +16227,7 @@
       "kb_article": "KB5039705",
       "release_type": "Out-of-band",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039705"
     },
     {
       "full_version": "10.0.17763.5830",
@@ -16239,7 +16239,7 @@
       "kb_article": "KB5039705",
       "release_type": "Out-of-band",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039705"
     },
     {
       "full_version": "10.0.19045.4474",
@@ -16251,7 +16251,7 @@
       "kb_article": "KB5037849",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037849"
     },
     {
       "full_version": "10.0.22621.3672",
@@ -16263,7 +16263,7 @@
       "kb_article": "KB5037853",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037853"
     },
     {
       "full_version": "10.0.22631.3672",
@@ -16275,7 +16275,7 @@
       "kb_article": "KB5037853",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5037853"
     },
     {
       "full_version": "10.0.14393.7070",
@@ -16287,7 +16287,7 @@
       "kb_article": "KB5039214",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039214"
     },
     {
       "full_version": "10.0.14393.7070",
@@ -16299,7 +16299,7 @@
       "kb_article": "KB5039214",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039214"
     },
     {
       "full_version": "10.0.17763.5936",
@@ -16311,7 +16311,7 @@
       "kb_article": "KB5039217",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039217"
     },
     {
       "full_version": "10.0.17763.5936",
@@ -16323,7 +16323,7 @@
       "kb_article": "KB5039217",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039217"
     },
     {
       "full_version": "10.0.19044.4529",
@@ -16335,7 +16335,7 @@
       "kb_article": "KB5039211",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039211"
     },
     {
       "full_version": "10.0.19045.4529",
@@ -16347,7 +16347,7 @@
       "kb_article": "KB5039211",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039211"
     },
     {
       "full_version": "10.0.20348.2527",
@@ -16359,7 +16359,7 @@
       "kb_article": "KB5039227",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039227"
     },
     {
       "full_version": "10.0.22000.3019",
@@ -16371,7 +16371,7 @@
       "kb_article": "KB5039213",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039213"
     },
     {
       "full_version": "10.0.22621.3737",
@@ -16383,7 +16383,7 @@
       "kb_article": "KB5039212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039212"
     },
     {
       "full_version": "10.0.22631.3737",
@@ -16395,7 +16395,7 @@
       "kb_article": "KB5039212",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039212"
     },
     {
       "full_version": "10.0.25398.950",
@@ -16407,7 +16407,7 @@
       "kb_article": "KB5039236",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039236"
     },
     {
       "full_version": "10.0.26100.863",
@@ -16419,7 +16419,7 @@
       "kb_article": "KB5039239",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039239"
     },
     {
       "full_version": "10.0.20348.2529",
@@ -16431,7 +16431,7 @@
       "kb_article": "KB5041054",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041054"
     },
     {
       "full_version": "10.0.19045.4598",
@@ -16443,7 +16443,7 @@
       "kb_article": "KB5039299",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039299"
     },
     {
       "full_version": "10.0.22621.3810",
@@ -16455,7 +16455,7 @@
       "kb_article": "KB5039302",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039302"
     },
     {
       "full_version": "10.0.22631.3810",
@@ -16467,7 +16467,7 @@
       "kb_article": "KB5039302",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039302"
     },
     {
       "full_version": "10.0.26100.1000",
@@ -16479,7 +16479,7 @@
       "kb_article": "KB5039304",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5039304"
     },
     {
       "full_version": "10.0.14393.7159",
@@ -16491,7 +16491,7 @@
       "kb_article": "KB5040434",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040434"
     },
     {
       "full_version": "10.0.14393.7159",
@@ -16503,7 +16503,7 @@
       "kb_article": "KB5040434",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040434"
     },
     {
       "full_version": "10.0.17763.6054",
@@ -16515,7 +16515,7 @@
       "kb_article": "KB5040430",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040430"
     },
     {
       "full_version": "10.0.17763.6054",
@@ -16527,7 +16527,7 @@
       "kb_article": "KB5040430",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040430"
     },
     {
       "full_version": "10.0.19044.4651",
@@ -16539,7 +16539,7 @@
       "kb_article": "KB5040427",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040427"
     },
     {
       "full_version": "10.0.19045.4651",
@@ -16551,7 +16551,7 @@
       "kb_article": "KB5040427",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040427"
     },
     {
       "full_version": "10.0.20348.2582",
@@ -16563,7 +16563,7 @@
       "kb_article": "KB5040437",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040437"
     },
     {
       "full_version": "10.0.22000.3079",
@@ -16575,7 +16575,7 @@
       "kb_article": "KB5040431",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040431"
     },
     {
       "full_version": "10.0.22621.3880",
@@ -16587,7 +16587,7 @@
       "kb_article": "KB5040442",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040442"
     },
     {
       "full_version": "10.0.22631.3880",
@@ -16599,7 +16599,7 @@
       "kb_article": "KB5040442",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040442"
     },
     {
       "full_version": "10.0.25398.1009",
@@ -16611,7 +16611,7 @@
       "kb_article": "KB5040438",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040438"
     },
     {
       "full_version": "10.0.26100.1150",
@@ -16623,7 +16623,7 @@
       "kb_article": "KB5040435",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040435"
     },
     {
       "full_version": "10.0.19045.4717",
@@ -16635,7 +16635,7 @@
       "kb_article": "KB5040525",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040525"
     },
     {
       "full_version": "10.0.22621.3958",
@@ -16647,7 +16647,7 @@
       "kb_article": "KB5040527",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040527"
     },
     {
       "full_version": "10.0.22631.3958",
@@ -16659,7 +16659,7 @@
       "kb_article": "KB5040527",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040527"
     },
     {
       "full_version": "10.0.26100.1301",
@@ -16671,7 +16671,7 @@
       "kb_article": "KB5040529",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5040529"
     },
     {
       "full_version": "10.0.14393.7259",
@@ -16683,7 +16683,7 @@
       "kb_article": "KB5041773",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041773"
     },
     {
       "full_version": "10.0.14393.7259",
@@ -16695,7 +16695,7 @@
       "kb_article": "KB5041773",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041773"
     },
     {
       "full_version": "10.0.17763.6189",
@@ -16707,7 +16707,7 @@
       "kb_article": "KB5041578",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041578"
     },
     {
       "full_version": "10.0.17763.6189",
@@ -16719,7 +16719,7 @@
       "kb_article": "KB5041578",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041578"
     },
     {
       "full_version": "10.0.19044.4780",
@@ -16731,7 +16731,7 @@
       "kb_article": "KB5041580",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041580"
     },
     {
       "full_version": "10.0.19045.4780",
@@ -16743,7 +16743,7 @@
       "kb_article": "KB5041580",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041580"
     },
     {
       "full_version": "10.0.20348.2655",
@@ -16755,7 +16755,7 @@
       "kb_article": "KB5041160",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041160"
     },
     {
       "full_version": "10.0.22000.3147",
@@ -16767,7 +16767,7 @@
       "kb_article": "KB5041592",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041592"
     },
     {
       "full_version": "10.0.22621.4037",
@@ -16779,7 +16779,7 @@
       "kb_article": "KB5041585",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041585"
     },
     {
       "full_version": "10.0.22631.4037",
@@ -16791,7 +16791,7 @@
       "kb_article": "KB5041585",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041585"
     },
     {
       "full_version": "10.0.25398.1085",
@@ -16803,7 +16803,7 @@
       "kb_article": "KB5041573",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041573"
     },
     {
       "full_version": "10.0.26100.1457",
@@ -16815,7 +16815,7 @@
       "kb_article": "KB5041571",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041571"
     },
     {
       "full_version": "10.0.22621.4112",
@@ -16827,7 +16827,7 @@
       "kb_article": "KB5041587",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041587"
     },
     {
       "full_version": "10.0.22631.4112",
@@ -16839,7 +16839,7 @@
       "kb_article": "KB5041587",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041587"
     },
     {
       "full_version": "10.0.26100.1591",
@@ -16851,7 +16851,7 @@
       "kb_article": "KB5041865",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041865"
     },
     {
       "full_version": "10.0.19045.4842",
@@ -16863,7 +16863,7 @@
       "kb_article": "KB5041582",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5041582"
     },
     {
       "full_version": "10.0.14393.7336",
@@ -16875,7 +16875,7 @@
       "kb_article": "KB5043051",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043051"
     },
     {
       "full_version": "10.0.14393.7336",
@@ -16887,7 +16887,7 @@
       "kb_article": "KB5043051",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043051"
     },
     {
       "full_version": "10.0.17763.6293",
@@ -16899,7 +16899,7 @@
       "kb_article": "KB5043050",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043050"
     },
     {
       "full_version": "10.0.17763.6293",
@@ -16911,7 +16911,7 @@
       "kb_article": "KB5043050",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043050"
     },
     {
       "full_version": "10.0.19044.4894",
@@ -16923,7 +16923,7 @@
       "kb_article": "KB5043064",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043064"
     },
     {
       "full_version": "10.0.19045.4894",
@@ -16935,7 +16935,7 @@
       "kb_article": "KB5043064",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043064"
     },
     {
       "full_version": "10.0.20348.2700",
@@ -16947,7 +16947,7 @@
       "kb_article": "KB5042881",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5042881"
     },
     {
       "full_version": "10.0.22000.3197",
@@ -16959,7 +16959,7 @@
       "kb_article": "KB5043067",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043067"
     },
     {
       "full_version": "10.0.22621.4169",
@@ -16971,7 +16971,7 @@
       "kb_article": "KB5043076",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043076"
     },
     {
       "full_version": "10.0.22631.4169",
@@ -16983,7 +16983,7 @@
       "kb_article": "KB5043076",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043076"
     },
     {
       "full_version": "10.0.25398.1128",
@@ -16995,7 +16995,7 @@
       "kb_article": "KB5043055",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043055"
     },
     {
       "full_version": "10.0.26100.1742",
@@ -17007,7 +17007,7 @@
       "kb_article": "KB5043080",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043080"
     },
     {
       "full_version": "10.0.19045.4957",
@@ -17019,7 +17019,7 @@
       "kb_article": "KB5043131",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043131"
     },
     {
       "full_version": "10.0.22621.4249",
@@ -17031,7 +17031,7 @@
       "kb_article": "KB5043145",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043145"
     },
     {
       "full_version": "10.0.22631.4249",
@@ -17043,7 +17043,7 @@
       "kb_article": "KB5043145",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043145"
     },
     {
       "full_version": "10.0.26100.1882",
@@ -17055,7 +17055,7 @@
       "kb_article": "KB5043178",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5043178"
     },
     {
       "full_version": "10.0.14393.7428",
@@ -17067,7 +17067,7 @@
       "kb_article": "KB5044293",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044293"
     },
     {
       "full_version": "10.0.14393.7428",
@@ -17079,7 +17079,7 @@
       "kb_article": "KB5044293",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044293"
     },
     {
       "full_version": "10.0.17763.6414",
@@ -17091,7 +17091,7 @@
       "kb_article": "KB5044277",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044277"
     },
     {
       "full_version": "10.0.17763.6414",
@@ -17103,7 +17103,7 @@
       "kb_article": "KB5044277",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044277"
     },
     {
       "full_version": "10.0.19044.5011",
@@ -17115,7 +17115,7 @@
       "kb_article": "KB5044273",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044273"
     },
     {
       "full_version": "10.0.19045.5011",
@@ -17127,7 +17127,7 @@
       "kb_article": "KB5044273",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044273"
     },
     {
       "full_version": "10.0.20348.2762",
@@ -17139,7 +17139,7 @@
       "kb_article": "KB5044281",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044281"
     },
     {
       "full_version": "10.0.22000.3260",
@@ -17151,7 +17151,7 @@
       "kb_article": "KB5044280",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044280"
     },
     {
       "full_version": "10.0.22621.4317",
@@ -17163,7 +17163,7 @@
       "kb_article": "KB5044285",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044285"
     },
     {
       "full_version": "10.0.22631.4317",
@@ -17175,7 +17175,7 @@
       "kb_article": "KB5044285",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044285"
     },
     {
       "full_version": "10.0.25398.1189",
@@ -17187,7 +17187,7 @@
       "kb_article": "KB5044288",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044288"
     },
     {
       "full_version": "10.0.26100.2033",
@@ -17199,7 +17199,7 @@
       "kb_article": "KB5044284",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044284"
     },
     {
       "full_version": "10.0.26100.2033",
@@ -17211,7 +17211,7 @@
       "kb_article": "KB5044284",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044284"
     },
     {
       "full_version": "10.0.19045.5073",
@@ -17223,7 +17223,7 @@
       "kb_article": "KB5045594",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5045594"
     },
     {
       "full_version": "10.0.22621.4391",
@@ -17235,7 +17235,7 @@
       "kb_article": "KB5044380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044380"
     },
     {
       "full_version": "10.0.22631.4391",
@@ -17247,7 +17247,7 @@
       "kb_article": "KB5044380",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044380"
     },
     {
       "full_version": "10.0.26100.2161",
@@ -17259,7 +17259,7 @@
       "kb_article": "KB5044384",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5044384"
     },
     {
       "full_version": "10.0.14393.7515",
@@ -17271,7 +17271,7 @@
       "kb_article": "KB5046612",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046612"
     },
     {
       "full_version": "10.0.14393.7515",
@@ -17283,7 +17283,7 @@
       "kb_article": "KB5046612",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046612"
     },
     {
       "full_version": "10.0.17763.6532",
@@ -17295,7 +17295,7 @@
       "kb_article": "KB5046615",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046615"
     },
     {
       "full_version": "10.0.17763.6532",
@@ -17307,7 +17307,7 @@
       "kb_article": "KB5046615",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046615"
     },
     {
       "full_version": "10.0.19044.5131",
@@ -17319,7 +17319,7 @@
       "kb_article": "KB5046613",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046613"
     },
     {
       "full_version": "10.0.19045.5131",
@@ -17331,7 +17331,7 @@
       "kb_article": "KB5046613",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046613"
     },
     {
       "full_version": "10.0.20348.2849",
@@ -17343,7 +17343,7 @@
       "kb_article": "KB5046616",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046616"
     },
     {
       "full_version": "10.0.22621.4460",
@@ -17355,7 +17355,7 @@
       "kb_article": "KB5046633",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046633"
     },
     {
       "full_version": "10.0.22631.4460",
@@ -17367,7 +17367,7 @@
       "kb_article": "KB5046633",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046633"
     },
     {
       "full_version": "10.0.25398.1251",
@@ -17379,7 +17379,7 @@
       "kb_article": "KB5046618",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046618"
     },
     {
       "full_version": "10.0.26100.2314",
@@ -17391,7 +17391,7 @@
       "kb_article": "KB5046617",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046617"
     },
     {
       "full_version": "10.0.26100.2314",
@@ -17403,7 +17403,7 @@
       "kb_article": "KB5046617",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046617"
     },
     {
       "full_version": "10.0.19045.5198",
@@ -17415,7 +17415,7 @@
       "kb_article": "KB5046714",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046714"
     },
     {
       "full_version": "10.0.22621.4541",
@@ -17427,7 +17427,7 @@
       "kb_article": "KB5046732",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046732"
     },
     {
       "full_version": "10.0.22631.4541",
@@ -17439,7 +17439,7 @@
       "kb_article": "KB5046732",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046732"
     },
     {
       "full_version": "10.0.26100.2454",
@@ -17451,7 +17451,7 @@
       "kb_article": "KB5046740",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5046740"
     },
     {
       "full_version": "10.0.14393.7606",
@@ -17463,7 +17463,7 @@
       "kb_article": "KB5048671",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048671"
     },
     {
       "full_version": "10.0.14393.7606",
@@ -17475,7 +17475,7 @@
       "kb_article": "KB5048671",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048671"
     },
     {
       "full_version": "10.0.17763.6659",
@@ -17487,7 +17487,7 @@
       "kb_article": "KB5048661",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048661"
     },
     {
       "full_version": "10.0.17763.6659",
@@ -17499,7 +17499,7 @@
       "kb_article": "KB5048661",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048661"
     },
     {
       "full_version": "10.0.19044.5247",
@@ -17511,7 +17511,7 @@
       "kb_article": "KB5048652",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048652"
     },
     {
       "full_version": "10.0.19045.5247",
@@ -17523,7 +17523,7 @@
       "kb_article": "KB5048652",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048652"
     },
     {
       "full_version": "10.0.20348.2966",
@@ -17535,7 +17535,7 @@
       "kb_article": "KB5048654",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048654"
     },
     {
       "full_version": "10.0.22621.4602",
@@ -17547,7 +17547,7 @@
       "kb_article": "KB5048685",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048685"
     },
     {
       "full_version": "10.0.22631.4602",
@@ -17559,7 +17559,7 @@
       "kb_article": "KB5048685",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048685"
     },
     {
       "full_version": "10.0.25398.1308",
@@ -17571,7 +17571,7 @@
       "kb_article": "KB5048653",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048653"
     },
     {
       "full_version": "10.0.26100.2605",
@@ -17583,7 +17583,7 @@
       "kb_article": "KB5048667",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048667"
     },
     {
       "full_version": "10.0.26100.2605",
@@ -17595,7 +17595,7 @@
       "kb_article": "KB5048667",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5048667"
     },
     {
       "full_version": "10.0.14393.7699",
@@ -17607,7 +17607,7 @@
       "kb_article": "KB5049993",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049993"
     },
     {
       "full_version": "10.0.14393.7699",
@@ -17619,7 +17619,7 @@
       "kb_article": "KB5049993",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049993"
     },
     {
       "full_version": "10.0.17763.6775",
@@ -17631,7 +17631,7 @@
       "kb_article": "KB5050008",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050008"
     },
     {
       "full_version": "10.0.17763.6775",
@@ -17643,7 +17643,7 @@
       "kb_article": "KB5050008",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050008"
     },
     {
       "full_version": "10.0.19044.5371",
@@ -17655,7 +17655,7 @@
       "kb_article": "KB5049981",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049981"
     },
     {
       "full_version": "10.0.19045.5371",
@@ -17667,7 +17667,7 @@
       "kb_article": "KB5049981",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049981"
     },
     {
       "full_version": "10.0.20348.3091",
@@ -17679,7 +17679,7 @@
       "kb_article": "KB5049983",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049983"
     },
     {
       "full_version": "10.0.22621.4751",
@@ -17691,7 +17691,7 @@
       "kb_article": "KB5050021",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050021"
     },
     {
       "full_version": "10.0.22631.4751",
@@ -17703,7 +17703,7 @@
       "kb_article": "KB5050021",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050021"
     },
     {
       "full_version": "10.0.25398.1369",
@@ -17715,7 +17715,7 @@
       "kb_article": "KB5049984",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5049984"
     },
     {
       "full_version": "10.0.26100.2894",
@@ -17727,7 +17727,7 @@
       "kb_article": "KB5050009",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050009"
     },
     {
       "full_version": "10.0.26100.2894",
@@ -17739,7 +17739,7 @@
       "kb_article": "KB5050009",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050009"
     },
     {
       "full_version": "10.0.19045.5440",
@@ -17751,7 +17751,7 @@
       "kb_article": "KB5050081",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050081"
     },
     {
       "full_version": "10.0.26100.3037",
@@ -17763,7 +17763,7 @@
       "kb_article": "KB5050094",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050094"
     },
     {
       "full_version": "10.0.22621.4830",
@@ -17775,7 +17775,7 @@
       "kb_article": "KB5050092",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050092"
     },
     {
       "full_version": "10.0.22631.4830",
@@ -17787,7 +17787,7 @@
       "kb_article": "KB5050092",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5050092"
     },
     {
       "full_version": "10.0.14393.7785",
@@ -17799,7 +17799,7 @@
       "kb_article": "KB5052006",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052006"
     },
     {
       "full_version": "10.0.14393.7785",
@@ -17811,7 +17811,7 @@
       "kb_article": "KB5052006",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052006"
     },
     {
       "full_version": "10.0.17763.6893",
@@ -17823,7 +17823,7 @@
       "kb_article": "KB5052000",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052000"
     },
     {
       "full_version": "10.0.17763.6893",
@@ -17835,7 +17835,7 @@
       "kb_article": "KB5052000",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052000"
     },
     {
       "full_version": "10.0.19044.5487",
@@ -17847,7 +17847,7 @@
       "kb_article": "KB5051974",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051974"
     },
     {
       "full_version": "10.0.19045.5487",
@@ -17859,7 +17859,7 @@
       "kb_article": "KB5051974",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051974"
     },
     {
       "full_version": "10.0.20348.3207",
@@ -17871,7 +17871,7 @@
       "kb_article": "KB5051979",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051979"
     },
     {
       "full_version": "10.0.22621.4890",
@@ -17883,7 +17883,7 @@
       "kb_article": "KB5051989",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051989"
     },
     {
       "full_version": "10.0.22631.4890",
@@ -17895,7 +17895,7 @@
       "kb_article": "KB5051989",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051989"
     },
     {
       "full_version": "10.0.25398.1425",
@@ -17907,7 +17907,7 @@
       "kb_article": "KB5051980",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051980"
     },
     {
       "full_version": "10.0.26100.3194",
@@ -17919,7 +17919,7 @@
       "kb_article": "KB5051987",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051987"
     },
     {
       "full_version": "10.0.26100.3194",
@@ -17931,7 +17931,7 @@
       "kb_article": "KB5051987",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5051987"
     },
     {
       "full_version": "10.0.19045.5555",
@@ -17943,7 +17943,7 @@
       "kb_article": "KB5052077",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052077"
     },
     {
       "full_version": "10.0.22621.4974",
@@ -17955,7 +17955,7 @@
       "kb_article": "KB5052094",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052094"
     },
     {
       "full_version": "10.0.22631.4974",
@@ -17967,7 +17967,7 @@
       "kb_article": "KB5052094",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052094"
     },
     {
       "full_version": "10.0.26100.3323",
@@ -17979,7 +17979,7 @@
       "kb_article": "KB5052093",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5052093"
     },
     {
       "full_version": "10.0.14393.7876",
@@ -17991,7 +17991,7 @@
       "kb_article": "KB5053594",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053594"
     },
     {
       "full_version": "10.0.14393.7876",
@@ -18003,7 +18003,7 @@
       "kb_article": "KB5053594",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053594"
     },
     {
       "full_version": "10.0.17763.7009",
@@ -18015,7 +18015,7 @@
       "kb_article": "KB5053596",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053596"
     },
     {
       "full_version": "10.0.17763.7009",
@@ -18027,7 +18027,7 @@
       "kb_article": "KB5053596",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053596"
     },
     {
       "full_version": "10.0.19044.5608",
@@ -18039,7 +18039,7 @@
       "kb_article": "KB5053606",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053606"
     },
     {
       "full_version": "10.0.19045.5608",
@@ -18051,7 +18051,7 @@
       "kb_article": "KB5053606",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053606"
     },
     {
       "full_version": "10.0.20348.3328",
@@ -18063,7 +18063,7 @@
       "kb_article": "KB5053603",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053603"
     },
     {
       "full_version": "10.0.22621.5039",
@@ -18075,7 +18075,7 @@
       "kb_article": "KB5053602",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053602"
     },
     {
       "full_version": "10.0.22631.5039",
@@ -18087,7 +18087,7 @@
       "kb_article": "KB5053602",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053602"
     },
     {
       "full_version": "10.0.25398.1486",
@@ -18099,7 +18099,7 @@
       "kb_article": "KB5053599",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053599"
     },
     {
       "full_version": "10.0.26100.3476",
@@ -18111,7 +18111,7 @@
       "kb_article": "KB5053598",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053598"
     },
     {
       "full_version": "10.0.26100.3476",
@@ -18123,7 +18123,7 @@
       "kb_article": "KB5053598",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053598"
     },
     {
       "full_version": "10.0.19045.5679",
@@ -18135,7 +18135,7 @@
       "kb_article": "KB5053643",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053643"
     },
     {
       "full_version": "10.0.22621.5126",
@@ -18147,7 +18147,7 @@
       "kb_article": "KB5053657",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053657"
     },
     {
       "full_version": "10.0.22631.5126",
@@ -18159,7 +18159,7 @@
       "kb_article": "KB5053657",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053657"
     },
     {
       "full_version": "10.0.26100.3624",
@@ -18171,7 +18171,7 @@
       "kb_article": "KB5053656",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5053656"
     },
     {
       "full_version": "10.0.14393.7969",
@@ -18183,7 +18183,7 @@
       "kb_article": "KB5055521",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055521"
     },
     {
       "full_version": "10.0.14393.7969",
@@ -18195,7 +18195,7 @@
       "kb_article": "KB5055521",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055521"
     },
     {
       "full_version": "10.0.17763.7136",
@@ -18207,7 +18207,7 @@
       "kb_article": "KB5055519",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055519"
     },
     {
       "full_version": "10.0.17763.7136",
@@ -18219,7 +18219,7 @@
       "kb_article": "KB5055519",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055519"
     },
     {
       "full_version": "10.0.19044.5736",
@@ -18231,7 +18231,7 @@
       "kb_article": "KB5055518",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055518"
     },
     {
       "full_version": "10.0.19044.5737",
@@ -18243,7 +18243,7 @@
       "kb_article": "KB5055518",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055518"
     },
     {
       "full_version": "10.0.19045.5736",
@@ -18255,7 +18255,7 @@
       "kb_article": "KB5055518",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055518"
     },
     {
       "full_version": "10.0.19045.5737",
@@ -18267,7 +18267,7 @@
       "kb_article": "KB5055518",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055518"
     },
     {
       "full_version": "10.0.20348.3453",
@@ -18279,7 +18279,7 @@
       "kb_article": "KB5055526",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055526"
     },
     {
       "full_version": "10.0.22621.5189",
@@ -18291,7 +18291,7 @@
       "kb_article": "KB5055528",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055528"
     },
     {
       "full_version": "10.0.22621.5191",
@@ -18303,7 +18303,7 @@
       "kb_article": "KB5055528",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055528"
     },
     {
       "full_version": "10.0.22631.5189",
@@ -18315,7 +18315,7 @@
       "kb_article": "KB5055528",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055528"
     },
     {
       "full_version": "10.0.22631.5191",
@@ -18327,7 +18327,7 @@
       "kb_article": "KB5055528",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055528"
     },
     {
       "full_version": "10.0.25398.1551",
@@ -18339,7 +18339,7 @@
       "kb_article": "KB5055527",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055527"
     },
     {
       "full_version": "10.0.26100.3775",
@@ -18351,7 +18351,7 @@
       "kb_article": "KB5055523",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055523"
     },
     {
       "full_version": "10.0.26100.3775",
@@ -18363,7 +18363,7 @@
       "kb_article": "KB5055523",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055523"
     },
     {
       "full_version": "10.0.14393.7973",
@@ -18375,7 +18375,7 @@
       "kb_article": "KB5058921",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058921"
     },
     {
       "full_version": "10.0.14393.7973",
@@ -18387,7 +18387,7 @@
       "kb_article": "KB5058921",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058921"
     },
     {
       "full_version": "10.0.17763.7240",
@@ -18399,7 +18399,7 @@
       "kb_article": "KB5058922",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058922"
     },
     {
       "full_version": "10.0.17763.7240",
@@ -18411,7 +18411,7 @@
       "kb_article": "KB5058922",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058922"
     },
     {
       "full_version": "10.0.20348.3561",
@@ -18423,7 +18423,7 @@
       "kb_article": "KB5058920",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058920"
     },
     {
       "full_version": "10.0.22621.5192",
@@ -18435,7 +18435,7 @@
       "kb_article": "KB5058919",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058919"
     },
     {
       "full_version": "10.0.22631.5192",
@@ -18447,7 +18447,7 @@
       "kb_article": "KB5058919",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058919"
     },
     {
       "full_version": "10.0.17763.7249",
@@ -18459,7 +18459,7 @@
       "kb_article": "KB5059091",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5059091"
     },
     {
       "full_version": "10.0.17763.7249",
@@ -18471,7 +18471,7 @@
       "kb_article": "KB5059091",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5059091"
     },
     {
       "full_version": "10.0.20348.3566",
@@ -18483,7 +18483,7 @@
       "kb_article": "KB5059092",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5059092"
     },
     {
       "full_version": "10.0.26100.3781",
@@ -18495,7 +18495,7 @@
       "kb_article": "KB5059087",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5059087"
     },
     {
       "full_version": "10.0.19045.5796",
@@ -18507,7 +18507,7 @@
       "kb_article": "KB5055612",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055612"
     },
     {
       "full_version": "10.0.22621.5262",
@@ -18519,7 +18519,7 @@
       "kb_article": "KB5055629",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055629"
     },
     {
       "full_version": "10.0.22631.5262",
@@ -18531,7 +18531,7 @@
       "kb_article": "KB5055629",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055629"
     },
     {
       "full_version": "10.0.26100.3915",
@@ -18543,7 +18543,7 @@
       "kb_article": "KB5055627",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5055627"
     },
     {
       "full_version": "10.0.14393.8066",
@@ -18555,7 +18555,7 @@
       "kb_article": "KB5058383",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058383"
     },
     {
       "full_version": "10.0.14393.8066",
@@ -18567,7 +18567,7 @@
       "kb_article": "KB5058383",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058383"
     },
     {
       "full_version": "10.0.17763.7314",
@@ -18579,7 +18579,7 @@
       "kb_article": "KB5058392",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058392"
     },
     {
       "full_version": "10.0.17763.7314",
@@ -18591,7 +18591,7 @@
       "kb_article": "KB5058392",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058392"
     },
     {
       "full_version": "10.0.19044.5854",
@@ -18603,7 +18603,7 @@
       "kb_article": "KB5058379",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058379"
     },
     {
       "full_version": "10.0.19045.5854",
@@ -18615,7 +18615,7 @@
       "kb_article": "KB5058379",
       "release_type": "Standard",
       "is_expired": true,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058379"
     },
     {
       "full_version": "10.0.20348.3692",
@@ -18627,7 +18627,7 @@
       "kb_article": "KB5058385",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058385"
     },
     {
       "full_version": "10.0.22621.5335",
@@ -18639,7 +18639,7 @@
       "kb_article": "KB5058405",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058405"
     },
     {
       "full_version": "10.0.22631.5335",
@@ -18651,7 +18651,7 @@
       "kb_article": "KB5058405",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058405"
     },
     {
       "full_version": "10.0.25398.1611",
@@ -18663,7 +18663,7 @@
       "kb_article": "KB5058384",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058384"
     },
     {
       "full_version": "10.0.26100.4061",
@@ -18675,7 +18675,7 @@
       "kb_article": "KB5058411",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058411"
     },
     {
       "full_version": "10.0.26100.4061",
@@ -18687,7 +18687,7 @@
       "kb_article": "KB5058411",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058411"
     },
     {
       "full_version": "10.0.19044.5856",
@@ -18699,7 +18699,7 @@
       "kb_article": "KB5061768",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061768"
     },
     {
       "full_version": "10.0.19045.5856",
@@ -18711,7 +18711,7 @@
       "kb_article": "KB5061768",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061768"
     },
     {
       "full_version": "10.0.20348.3695",
@@ -18723,7 +18723,7 @@
       "kb_article": "KB5061906",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061906"
     },
     {
       "full_version": "10.0.17763.7322",
@@ -18735,7 +18735,7 @@
       "kb_article": "KB5061978",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061978"
     },
     {
       "full_version": "10.0.17763.7322",
@@ -18747,7 +18747,7 @@
       "kb_article": "KB5061978",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061978"
     },
     {
       "full_version": "10.0.19044.5859",
@@ -18759,7 +18759,7 @@
       "kb_article": "KB5061979",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061979"
     },
     {
       "full_version": "10.0.19045.5859",
@@ -18771,7 +18771,7 @@
       "kb_article": "KB5061979",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061979"
     },
     {
       "full_version": "10.0.22621.5413",
@@ -18783,7 +18783,7 @@
       "kb_article": "KB5058502",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058502"
     },
     {
       "full_version": "10.0.22631.5413",
@@ -18795,7 +18795,7 @@
       "kb_article": "KB5058502",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058502"
     },
     {
       "full_version": "10.0.26100.4066",
@@ -18807,7 +18807,7 @@
       "kb_article": "KB5061977",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061977"
     },
     {
       "full_version": "10.0.26100.4066",
@@ -18819,7 +18819,7 @@
       "kb_article": "KB5061977",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061977"
     },
     {
       "full_version": "10.0.19045.5917",
@@ -18831,7 +18831,7 @@
       "kb_article": "KB5058481",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058481"
     },
     {
       "full_version": "10.0.26100.4202",
@@ -18843,7 +18843,7 @@
       "kb_article": "KB5058499",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5058499"
     },
     {
       "full_version": "10.0.22621.5415",
@@ -18855,7 +18855,7 @@
       "kb_article": "KB5062170",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062170"
     },
     {
       "full_version": "10.0.22631.5415",
@@ -18867,7 +18867,7 @@
       "kb_article": "KB5062170",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062170"
     },
     {
       "full_version": "10.0.14393.8148",
@@ -18879,7 +18879,7 @@
       "kb_article": "KB5061010",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061010"
     },
     {
       "full_version": "10.0.14393.8148",
@@ -18891,7 +18891,7 @@
       "kb_article": "KB5061010",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061010"
     },
     {
       "full_version": "10.0.17763.7434",
@@ -18903,7 +18903,7 @@
       "kb_article": "KB5060531",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060531"
     },
     {
       "full_version": "10.0.17763.7434",
@@ -18915,7 +18915,7 @@
       "kb_article": "KB5060531",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060531"
     },
     {
       "full_version": "10.0.19044.5965",
@@ -18927,7 +18927,7 @@
       "kb_article": "KB5060533",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060533"
     },
     {
       "full_version": "10.0.19045.5965",
@@ -18939,7 +18939,7 @@
       "kb_article": "KB5060533",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060533"
     },
     {
       "full_version": "10.0.20348.3807",
@@ -18951,7 +18951,7 @@
       "kb_article": "KB5060526",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060526"
     },
     {
       "full_version": "10.0.22621.5472",
@@ -18963,7 +18963,7 @@
       "kb_article": "KB5060999",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060999"
     },
     {
       "full_version": "10.0.22631.5472",
@@ -18975,7 +18975,7 @@
       "kb_article": "KB5060999",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060999"
     },
     {
       "full_version": "10.0.25398.1665",
@@ -18987,7 +18987,7 @@
       "kb_article": "KB5060118",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060118"
     },
     {
       "full_version": "10.0.26100.4349",
@@ -18999,7 +18999,7 @@
       "kb_article": "KB5060842",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060842"
     },
     {
       "full_version": "10.0.26100.4349",
@@ -19011,7 +19011,7 @@
       "kb_article": "KB5060842",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060842"
     },
     {
       "full_version": "10.0.26100.4351",
@@ -19023,7 +19023,7 @@
       "kb_article": "KB5063060",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063060"
     },
     {
       "full_version": "10.0.19045.5968",
@@ -19035,7 +19035,7 @@
       "kb_article": "KB5063159",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063159"
     },
     {
       "full_version": "10.0.19045.6036",
@@ -19047,7 +19047,7 @@
       "kb_article": "KB5061087",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5061087"
     },
     {
       "full_version": "10.0.22621.5549",
@@ -19059,7 +19059,7 @@
       "kb_article": "KB5060826",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060826"
     },
     {
       "full_version": "10.0.22631.5549",
@@ -19071,7 +19071,7 @@
       "kb_article": "KB5060826",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060826"
     },
     {
       "full_version": "10.0.26100.4484",
@@ -19083,7 +19083,7 @@
       "kb_article": "KB5060829",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5060829"
     },
     {
       "full_version": "10.0.25398.1668",
@@ -19095,7 +19095,7 @@
       "kb_article": "KB5063774",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063774"
     },
     {
       "full_version": "10.0.14393.8246",
@@ -19107,7 +19107,7 @@
       "kb_article": "KB5062560",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062560"
     },
     {
       "full_version": "10.0.14393.8246",
@@ -19119,7 +19119,7 @@
       "kb_article": "KB5062560",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062560"
     },
     {
       "full_version": "10.0.17763.7558",
@@ -19131,7 +19131,7 @@
       "kb_article": "KB5062557",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062557"
     },
     {
       "full_version": "10.0.17763.7558",
@@ -19143,7 +19143,7 @@
       "kb_article": "KB5062557",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062557"
     },
     {
       "full_version": "10.0.19044.6093",
@@ -19155,7 +19155,7 @@
       "kb_article": "KB5062554",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062554"
     },
     {
       "full_version": "10.0.19045.6093",
@@ -19167,7 +19167,7 @@
       "kb_article": "KB5062554",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062554"
     },
     {
       "full_version": "10.0.20348.3932",
@@ -19179,7 +19179,7 @@
       "kb_article": "KB5062572",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062572"
     },
     {
       "full_version": "10.0.22621.5624",
@@ -19191,7 +19191,7 @@
       "kb_article": "KB5062552",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062552"
     },
     {
       "full_version": "10.0.22631.5624",
@@ -19203,7 +19203,7 @@
       "kb_article": "KB5062552",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062552"
     },
     {
       "full_version": "10.0.25398.1732",
@@ -19215,7 +19215,7 @@
       "kb_article": "KB5062570",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062570"
     },
     {
       "full_version": "10.0.26100.4652",
@@ -19227,7 +19227,7 @@
       "kb_article": "KB5062553",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062553"
     },
     {
       "full_version": "10.0.26100.4652",
@@ -19239,7 +19239,7 @@
       "kb_article": "KB5062553",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062553"
     },
     {
       "full_version": "10.0.26100.4656",
@@ -19251,7 +19251,7 @@
       "kb_article": "KB5064489",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5064489"
     },
     {
       "full_version": "10.0.26100.4656",
@@ -19263,7 +19263,7 @@
       "kb_article": "KB5064489",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5064489"
     },
     {
       "full_version": "10.0.19045.6159",
@@ -19275,7 +19275,7 @@
       "kb_article": "KB5062649",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062649"
     },
     {
       "full_version": "10.0.22621.5699",
@@ -19287,7 +19287,7 @@
       "kb_article": "KB5062663",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062663"
     },
     {
       "full_version": "10.0.22631.5699",
@@ -19299,7 +19299,7 @@
       "kb_article": "KB5062663",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062663"
     },
     {
       "full_version": "10.0.26100.4770",
@@ -19311,7 +19311,7 @@
       "kb_article": "KB5062660",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5062660"
     },
     {
       "full_version": "10.0.14393.8330",
@@ -19323,7 +19323,7 @@
       "kb_article": "KB5063871",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063871"
     },
     {
       "full_version": "10.0.14393.8330",
@@ -19335,7 +19335,7 @@
       "kb_article": "KB5063871",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063871"
     },
     {
       "full_version": "10.0.17763.7678",
@@ -19347,7 +19347,7 @@
       "kb_article": "KB5063877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063877"
     },
     {
       "full_version": "10.0.17763.7678",
@@ -19359,7 +19359,7 @@
       "kb_article": "KB5063877",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063877"
     },
     {
       "full_version": "10.0.19044.6216",
@@ -19371,7 +19371,7 @@
       "kb_article": "KB5063709",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063709"
     },
     {
       "full_version": "10.0.19045.6216",
@@ -19383,7 +19383,7 @@
       "kb_article": "KB5063709",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063709"
     },
     {
       "full_version": "10.0.20348.4052",
@@ -19395,7 +19395,7 @@
       "kb_article": "KB5063880",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063880"
     },
     {
       "full_version": "10.0.22621.5768",
@@ -19407,7 +19407,7 @@
       "kb_article": "KB5063875",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063875"
     },
     {
       "full_version": "10.0.22631.5768",
@@ -19419,7 +19419,7 @@
       "kb_article": "KB5063875",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063875"
     },
     {
       "full_version": "10.0.25398.1791",
@@ -19431,7 +19431,7 @@
       "kb_article": "KB5063899",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063899"
     },
     {
       "full_version": "10.0.26100.4946",
@@ -19443,7 +19443,7 @@
       "kb_article": "KB5063878",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063878"
     },
     {
       "full_version": "10.0.26100.4946",
@@ -19455,7 +19455,7 @@
       "kb_article": "KB5063878",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063878"
     },
     {
       "full_version": "10.0.17763.7683",
@@ -19467,7 +19467,7 @@
       "kb_article": "KB5066187",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066187"
     },
     {
       "full_version": "10.0.17763.7683",
@@ -19479,7 +19479,7 @@
       "kb_article": "KB5066187",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066187"
     },
     {
       "full_version": "10.0.19044.6218",
@@ -19491,7 +19491,7 @@
       "kb_article": "KB5066188",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066188"
     },
     {
       "full_version": "10.0.19045.6218",
@@ -19503,7 +19503,7 @@
       "kb_article": "KB5066188",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066188"
     },
     {
       "full_version": "10.0.22621.5771",
@@ -19515,7 +19515,7 @@
       "kb_article": "KB5066189",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066189"
     },
     {
       "full_version": "10.0.22631.5771",
@@ -19527,7 +19527,7 @@
       "kb_article": "KB5066189",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066189"
     },
     {
       "full_version": "10.0.19045.6282",
@@ -19539,7 +19539,7 @@
       "kb_article": "KB5063842",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5063842"
     },
     {
       "full_version": "10.0.22631.5840",
@@ -19551,7 +19551,7 @@
       "kb_article": "KB5064080",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5064080"
     },
     {
       "full_version": "10.0.26100.5074",
@@ -19563,7 +19563,7 @@
       "kb_article": "KB5064081",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5064081"
     },
     {
       "full_version": "10.0.14393.8422",
@@ -19575,7 +19575,7 @@
       "kb_article": "KB5065427",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065427"
     },
     {
       "full_version": "10.0.14393.8422",
@@ -19587,7 +19587,7 @@
       "kb_article": "KB5065427",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065427"
     },
     {
       "full_version": "10.0.17763.7792",
@@ -19599,7 +19599,7 @@
       "kb_article": "KB5065428",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065428"
     },
     {
       "full_version": "10.0.17763.7792",
@@ -19611,7 +19611,7 @@
       "kb_article": "KB5065428",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065428"
     },
     {
       "full_version": "10.0.19044.6332",
@@ -19623,7 +19623,7 @@
       "kb_article": "KB5065429",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065429"
     },
     {
       "full_version": "10.0.19045.6332",
@@ -19635,7 +19635,7 @@
       "kb_article": "KB5065429",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065429"
     },
     {
       "full_version": "10.0.20348.4171",
@@ -19647,7 +19647,7 @@
       "kb_article": "KB5065432",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065432"
     },
     {
       "full_version": "10.0.22621.5909",
@@ -19659,7 +19659,7 @@
       "kb_article": "KB5065431",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065431"
     },
     {
       "full_version": "10.0.22631.5909",
@@ -19671,7 +19671,7 @@
       "kb_article": "KB5065431",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065431"
     },
     {
       "full_version": "10.0.25398.1849",
@@ -19683,7 +19683,7 @@
       "kb_article": "KB5065425",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065425"
     },
     {
       "full_version": "10.0.26100.6584",
@@ -19695,7 +19695,7 @@
       "kb_article": "KB5065426",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065426"
     },
     {
       "full_version": "10.0.26100.6584",
@@ -19707,7 +19707,7 @@
       "kb_article": "KB5065426",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065426"
     },
     {
       "full_version": "10.0.26100.6588",
@@ -19719,7 +19719,7 @@
       "kb_article": "KB5068221",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068221"
     },
     {
       "full_version": "10.0.26100.6588",
@@ -19731,7 +19731,7 @@
       "kb_article": "KB5068221",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068221"
     },
     {
       "full_version": "10.0.22631.5984",
@@ -19743,7 +19743,7 @@
       "kb_article": "KB5065790",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065790"
     },
     {
       "full_version": "10.0.19045.6396",
@@ -19755,7 +19755,7 @@
       "kb_article": "KB5066198",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066198"
     },
     {
       "full_version": "10.0.26100.6725",
@@ -19767,7 +19767,7 @@
       "kb_article": "KB5065789",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5065789"
     },
     {
       "full_version": "10.0.14393.8519",
@@ -19779,7 +19779,7 @@
       "kb_article": "KB5066836",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066836"
     },
     {
       "full_version": "10.0.14393.8519",
@@ -19791,7 +19791,7 @@
       "kb_article": "KB5066836",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066836"
     },
     {
       "full_version": "10.0.17763.7919",
@@ -19803,7 +19803,7 @@
       "kb_article": "KB5066586",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066586"
     },
     {
       "full_version": "10.0.17763.7919",
@@ -19815,7 +19815,7 @@
       "kb_article": "KB5066586",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066586"
     },
     {
       "full_version": "10.0.19044.6456",
@@ -19827,7 +19827,7 @@
       "kb_article": "KB5066791",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066791"
     },
     {
       "full_version": "10.0.19045.6456",
@@ -19839,7 +19839,7 @@
       "kb_article": "KB5066791",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066791"
     },
     {
       "full_version": "10.0.20348.4294",
@@ -19851,7 +19851,7 @@
       "kb_article": "KB5066782",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066782"
     },
     {
       "full_version": "10.0.22621.6060",
@@ -19863,7 +19863,7 @@
       "kb_article": "KB5066793",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066793"
     },
     {
       "full_version": "10.0.22631.6060",
@@ -19875,7 +19875,7 @@
       "kb_article": "KB5066793",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066793"
     },
     {
       "full_version": "10.0.25398.1913",
@@ -19887,7 +19887,7 @@
       "kb_article": "KB5066780",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066780"
     },
     {
       "full_version": "10.0.26100.6899",
@@ -19899,7 +19899,7 @@
       "kb_article": "KB5066835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066835"
     },
     {
       "full_version": "10.0.26100.6899",
@@ -19911,7 +19911,7 @@
       "kb_article": "KB5066835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066835"
     },
     {
       "full_version": "10.0.26200.6899",
@@ -19923,7 +19923,7 @@
       "kb_article": "KB5066835",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5066835"
     },
     {
       "full_version": "10.0.26100.6901",
@@ -19935,7 +19935,7 @@
       "kb_article": "KB5070773",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070773"
     },
     {
       "full_version": "10.0.26100.6901",
@@ -19947,7 +19947,7 @@
       "kb_article": "KB5070773",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070773"
     },
     {
       "full_version": "10.0.26200.6901",
@@ -19959,7 +19959,7 @@
       "kb_article": "KB5070773",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070773"
     },
     {
       "full_version": "10.0.20348.4297",
@@ -19971,7 +19971,7 @@
       "kb_article": "KB5070884",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070884"
     },
     {
       "full_version": "10.0.25398.1916",
@@ -19983,7 +19983,7 @@
       "kb_article": "KB5070879",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070879"
     },
     {
       "full_version": "10.0.26100.6905",
@@ -19995,7 +19995,7 @@
       "kb_article": "KB5070881",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070881"
     },
     {
       "full_version": "10.0.22631.6133",
@@ -20007,7 +20007,7 @@
       "kb_article": "KB5067112",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5067112"
     },
     {
       "full_version": "10.0.26100.7019",
@@ -20019,7 +20019,7 @@
       "kb_article": "KB5067036",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5067036"
     },
     {
       "full_version": "10.0.26200.7019",
@@ -20031,7 +20031,7 @@
       "kb_article": "KB5067036",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5067036"
     },
     {
       "full_version": "10.0.14393.8594",
@@ -20043,7 +20043,7 @@
       "kb_article": "KB5068864",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068864"
     },
     {
       "full_version": "10.0.14393.8594",
@@ -20055,7 +20055,7 @@
       "kb_article": "KB5068864",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068864"
     },
     {
       "full_version": "10.0.17763.8027",
@@ -20067,7 +20067,7 @@
       "kb_article": "KB5068791",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068791"
     },
     {
       "full_version": "10.0.17763.8027",
@@ -20079,7 +20079,7 @@
       "kb_article": "KB5068791",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068791"
     },
     {
       "full_version": "10.0.19044.6575",
@@ -20091,7 +20091,7 @@
       "kb_article": "KB5068781",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068781"
     },
     {
       "full_version": "10.0.19045.6466",
@@ -20103,7 +20103,7 @@
       "kb_article": "KB5071959",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071959"
     },
     {
       "full_version": "10.0.19045.6575",
@@ -20115,7 +20115,7 @@
       "kb_article": "KB5068781",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068781"
     },
     {
       "full_version": "10.0.20348.4405",
@@ -20127,7 +20127,7 @@
       "kb_article": "KB5068787",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068787"
     },
     {
       "full_version": "10.0.22631.6199",
@@ -20139,7 +20139,7 @@
       "kb_article": "KB5068865",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068865"
     },
     {
       "full_version": "10.0.25398.1965",
@@ -20151,7 +20151,7 @@
       "kb_article": "KB5068779",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068779"
     },
     {
       "full_version": "10.0.26100.7092",
@@ -20163,7 +20163,7 @@
       "kb_article": "KB5068966",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068966"
     },
     {
       "full_version": "10.0.26100.7171",
@@ -20175,7 +20175,7 @@
       "kb_article": "KB5068861",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068861"
     },
     {
       "full_version": "10.0.26100.7171",
@@ -20187,7 +20187,7 @@
       "kb_article": "KB5068861",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068861"
     },
     {
       "full_version": "10.0.26200.7092",
@@ -20199,7 +20199,7 @@
       "kb_article": "KB5068966",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068966"
     },
     {
       "full_version": "10.0.26200.7171",
@@ -20211,7 +20211,7 @@
       "kb_article": "KB5068861",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5068861"
     },
     {
       "full_version": "10.0.26100.7178",
@@ -20223,7 +20223,7 @@
       "kb_article": "KB5072359",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072359"
     },
     {
       "full_version": "10.0.22631.6276",
@@ -20235,7 +20235,7 @@
       "kb_article": "KB5070312",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070312"
     },
     {
       "full_version": "10.0.26100.7309",
@@ -20247,7 +20247,7 @@
       "kb_article": "KB5070311",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070311"
     },
     {
       "full_version": "10.0.26200.7309",
@@ -20259,7 +20259,7 @@
       "kb_article": "KB5070311",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5070311"
     },
     {
       "full_version": "10.0.14393.8688",
@@ -20271,7 +20271,7 @@
       "kb_article": "KB5071543",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071543"
     },
     {
       "full_version": "10.0.14393.8688",
@@ -20283,7 +20283,7 @@
       "kb_article": "KB5071543",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071543"
     },
     {
       "full_version": "10.0.17763.8146",
@@ -20295,7 +20295,7 @@
       "kb_article": "KB5071544",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071544"
     },
     {
       "full_version": "10.0.17763.8146",
@@ -20307,7 +20307,7 @@
       "kb_article": "KB5071544",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071544"
     },
     {
       "full_version": "10.0.19044.6691",
@@ -20319,7 +20319,7 @@
       "kb_article": "KB5071546",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071546"
     },
     {
       "full_version": "10.0.19045.6691",
@@ -20331,7 +20331,7 @@
       "kb_article": "KB5071546",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071546"
     },
     {
       "full_version": "10.0.20348.4529",
@@ -20343,7 +20343,7 @@
       "kb_article": "KB5071547",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071547"
     },
     {
       "full_version": "10.0.22631.6345",
@@ -20355,7 +20355,7 @@
       "kb_article": "KB5071417",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071417"
     },
     {
       "full_version": "10.0.25398.2025",
@@ -20367,7 +20367,7 @@
       "kb_article": "KB5071542",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5071542"
     },
     {
       "full_version": "10.0.26100.7392",
@@ -20379,7 +20379,7 @@
       "kb_article": "KB5072014",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072014"
     },
     {
       "full_version": "10.0.26100.7462",
@@ -20391,7 +20391,7 @@
       "kb_article": "KB5072033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072033"
     },
     {
       "full_version": "10.0.26100.7462",
@@ -20403,7 +20403,7 @@
       "kb_article": "KB5072033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072033"
     },
     {
       "full_version": "10.0.26200.7392",
@@ -20415,7 +20415,7 @@
       "kb_article": "KB5072014",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072014"
     },
     {
       "full_version": "10.0.26200.7462",
@@ -20427,7 +20427,7 @@
       "kb_article": "KB5072033",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5072033"
     },
     {
       "full_version": "10.0.14393.8692",
@@ -20439,7 +20439,7 @@
       "kb_article": "KB5074974",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074974"
     },
     {
       "full_version": "10.0.14393.8692",
@@ -20451,7 +20451,7 @@
       "kb_article": "KB5074974",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074974"
     },
     {
       "full_version": "10.0.17763.8148",
@@ -20463,7 +20463,7 @@
       "kb_article": "KB5074975",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074975"
     },
     {
       "full_version": "10.0.17763.8148",
@@ -20475,7 +20475,7 @@
       "kb_article": "KB5074975",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074975"
     },
     {
       "full_version": "10.0.19044.6693",
@@ -20487,7 +20487,7 @@
       "kb_article": "KB5074976",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074976"
     },
     {
       "full_version": "10.0.19045.6693",
@@ -20499,7 +20499,7 @@
       "kb_article": "KB5074976",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074976"
     },
     {
       "full_version": "10.0.14393.8783",
@@ -20511,7 +20511,7 @@
       "kb_article": "KB5073722",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073722"
     },
     {
       "full_version": "10.0.14393.8783",
@@ -20523,7 +20523,7 @@
       "kb_article": "KB5073722",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073722"
     },
     {
       "full_version": "10.0.17763.8276",
@@ -20535,7 +20535,7 @@
       "kb_article": "KB5073723",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073723"
     },
     {
       "full_version": "10.0.17763.8276",
@@ -20547,7 +20547,7 @@
       "kb_article": "KB5073723",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073723"
     },
     {
       "full_version": "10.0.19044.6809",
@@ -20559,7 +20559,7 @@
       "kb_article": "KB5073724",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073724"
     },
     {
       "full_version": "10.0.19045.6809",
@@ -20571,7 +20571,7 @@
       "kb_article": "KB5073724",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073724"
     },
     {
       "full_version": "10.0.20348.4648",
@@ -20583,7 +20583,7 @@
       "kb_article": "KB5073457",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073457"
     },
     {
       "full_version": "10.0.22631.6491",
@@ -20595,7 +20595,7 @@
       "kb_article": "KB5073455",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073455"
     },
     {
       "full_version": "10.0.25398.2092",
@@ -20607,7 +20607,7 @@
       "kb_article": "KB5073450",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073450"
     },
     {
       "full_version": "10.0.26100.32230",
@@ -20619,7 +20619,7 @@
       "kb_article": "KB5073379",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5073379"
     },
     {
       "full_version": "10.0.26100.7623",
@@ -20631,7 +20631,7 @@
       "kb_article": "KB5074109",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074109"
     },
     {
       "full_version": "10.0.26200.7623",
@@ -20643,7 +20643,7 @@
       "kb_article": "KB5074109",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074109"
     },
     {
       "full_version": "10.0.17763.8280",
@@ -20655,7 +20655,7 @@
       "kb_article": "KB5077795",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077795"
     },
     {
       "full_version": "10.0.17763.8280",
@@ -20667,7 +20667,7 @@
       "kb_article": "KB5077795",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077795"
     },
     {
       "full_version": "10.0.19044.6811",
@@ -20679,7 +20679,7 @@
       "kb_article": "KB5077796",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077796"
     },
     {
       "full_version": "10.0.19045.6811",
@@ -20691,7 +20691,7 @@
       "kb_article": "KB5077796",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077796"
     },
     {
       "full_version": "10.0.20348.4650",
@@ -20703,7 +20703,7 @@
       "kb_article": "KB5077800",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077800"
     },
     {
       "full_version": "10.0.22631.6494",
@@ -20715,7 +20715,7 @@
       "kb_article": "KB5077797",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077797"
     },
     {
       "full_version": "10.0.25398.2096",
@@ -20727,7 +20727,7 @@
       "kb_article": "KB5077792",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077792"
     },
     {
       "full_version": "10.0.26100.32234",
@@ -20739,7 +20739,7 @@
       "kb_article": "KB5077793",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077793"
     },
     {
       "full_version": "10.0.26100.7627",
@@ -20751,7 +20751,7 @@
       "kb_article": "KB5077744",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077744"
     },
     {
       "full_version": "10.0.26200.7627",
@@ -20763,7 +20763,7 @@
       "kb_article": "KB5077744",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077744"
     },
     {
       "full_version": "10.0.17763.8281",
@@ -20775,7 +20775,7 @@
       "kb_article": "KB5078131",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078131"
     },
     {
       "full_version": "10.0.17763.8281",
@@ -20787,7 +20787,7 @@
       "kb_article": "KB5078131",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078131"
     },
     {
       "full_version": "10.0.19044.6812",
@@ -20799,7 +20799,7 @@
       "kb_article": "KB5078129",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078129"
     },
     {
       "full_version": "10.0.19045.6812",
@@ -20811,7 +20811,7 @@
       "kb_article": "KB5078129",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078129"
     },
     {
       "full_version": "10.0.20348.4651",
@@ -20823,7 +20823,7 @@
       "kb_article": "KB5078136",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078136"
     },
     {
       "full_version": "10.0.22631.6495",
@@ -20835,7 +20835,7 @@
       "kb_article": "KB5078132",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078132"
     },
     {
       "full_version": "10.0.25398.2097",
@@ -20847,7 +20847,7 @@
       "kb_article": "KB5078133",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078133"
     },
     {
       "full_version": "10.0.26100.32236",
@@ -20859,7 +20859,7 @@
       "kb_article": "KB5078135",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078135"
     },
     {
       "full_version": "10.0.26100.7628",
@@ -20871,7 +20871,7 @@
       "kb_article": "KB5078127",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078127"
     },
     {
       "full_version": "10.0.26200.7628",
@@ -20883,7 +20883,7 @@
       "kb_article": "KB5078127",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078127"
     },
     {
       "full_version": "10.0.26100.7705",
@@ -20895,7 +20895,7 @@
       "kb_article": "KB5074105",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074105"
     },
     {
       "full_version": "10.0.26200.7705",
@@ -20907,7 +20907,7 @@
       "kb_article": "KB5074105",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5074105"
     },
     {
       "full_version": "10.0.14393.8868",
@@ -20919,7 +20919,7 @@
       "kb_article": "KB5075999",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075999"
     },
     {
       "full_version": "10.0.14393.8868",
@@ -20931,7 +20931,7 @@
       "kb_article": "KB5075999",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075999"
     },
     {
       "full_version": "10.0.17763.8389",
@@ -20943,7 +20943,7 @@
       "kb_article": "KB5075904",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075904"
     },
     {
       "full_version": "10.0.17763.8389",
@@ -20955,7 +20955,7 @@
       "kb_article": "KB5075904",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075904"
     },
     {
       "full_version": "10.0.19044.6937",
@@ -20967,7 +20967,7 @@
       "kb_article": "KB5075912",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075912"
     },
     {
       "full_version": "10.0.19045.6937",
@@ -20979,7 +20979,7 @@
       "kb_article": "KB5075912",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075912"
     },
     {
       "full_version": "10.0.20348.4773",
@@ -20991,7 +20991,7 @@
       "kb_article": "KB5075906",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075906"
     },
     {
       "full_version": "10.0.22631.6649",
@@ -21003,7 +21003,7 @@
       "kb_article": "KB5075941",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075941"
     },
     {
       "full_version": "10.0.25398.2149",
@@ -21015,7 +21015,7 @@
       "kb_article": "KB5075897",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075897"
     },
     {
       "full_version": "10.0.26100.32370",
@@ -21027,7 +21027,7 @@
       "kb_article": "KB5075899",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5075899"
     },
     {
       "full_version": "10.0.26100.7781",
@@ -21039,7 +21039,7 @@
       "kb_article": "KB5077212",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077212"
     },
     {
       "full_version": "10.0.26100.7840",
@@ -21051,7 +21051,7 @@
       "kb_article": "KB5077181",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077181"
     },
     {
       "full_version": "10.0.26200.7781",
@@ -21063,7 +21063,7 @@
       "kb_article": "KB5077212",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077212"
     },
     {
       "full_version": "10.0.26200.7840",
@@ -21075,7 +21075,7 @@
       "kb_article": "KB5077181",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077181"
     },
     {
       "full_version": "10.0.28000.1575",
@@ -21087,7 +21087,7 @@
       "kb_article": "KB5077179",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077179"
     },
     {
       "full_version": "10.0.26100.7922",
@@ -21099,7 +21099,7 @@
       "kb_article": "KB5077241",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077241"
     },
     {
       "full_version": "10.0.26200.7922",
@@ -21111,7 +21111,7 @@
       "kb_article": "KB5077241",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077241"
     },
     {
       "full_version": "10.0.28000.1643",
@@ -21123,7 +21123,7 @@
       "kb_article": "KB5077239",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5077239"
     },
     {
       "full_version": "10.0.20348.4776",
@@ -21135,7 +21135,7 @@
       "kb_article": "KB5082314",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082314"
     },
     {
       "full_version": "10.0.14393.8957",
@@ -21147,7 +21147,7 @@
       "kb_article": "KB5078938",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078938"
     },
     {
       "full_version": "10.0.14393.8957",
@@ -21159,7 +21159,7 @@
       "kb_article": "KB5078938",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078938"
     },
     {
       "full_version": "10.0.17763.8511",
@@ -21171,7 +21171,7 @@
       "kb_article": "KB5078752",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078752"
     },
     {
       "full_version": "10.0.17763.8511",
@@ -21183,7 +21183,7 @@
       "kb_article": "KB5078752",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078752"
     },
     {
       "full_version": "10.0.19044.7058",
@@ -21195,7 +21195,7 @@
       "kb_article": "KB5078885",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078885"
     },
     {
       "full_version": "10.0.19045.7058",
@@ -21207,7 +21207,7 @@
       "kb_article": "KB5078885",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078885"
     },
     {
       "full_version": "10.0.20348.4893",
@@ -21219,7 +21219,7 @@
       "kb_article": "KB5078766",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078766"
     },
     {
       "full_version": "10.0.22631.6783",
@@ -21231,7 +21231,7 @@
       "kb_article": "KB5078883",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078883"
     },
     {
       "full_version": "10.0.25398.2207",
@@ -21243,7 +21243,7 @@
       "kb_article": "KB5078734",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078734"
     },
     {
       "full_version": "10.0.26100.32522",
@@ -21255,7 +21255,7 @@
       "kb_article": "KB5078740",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5078740"
     },
     {
       "full_version": "10.0.26100.7979",
@@ -21267,7 +21267,7 @@
       "kb_article": "KB5079420",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079420"
     },
     {
       "full_version": "10.0.26100.8037",
@@ -21279,7 +21279,7 @@
       "kb_article": "KB5079473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079473"
     },
     {
       "full_version": "10.0.26200.7979",
@@ -21291,7 +21291,7 @@
       "kb_article": "KB5079420",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079420"
     },
     {
       "full_version": "10.0.26200.8037",
@@ -21303,7 +21303,7 @@
       "kb_article": "KB5079473",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079473"
     },
     {
       "full_version": "10.0.28000.1719",
@@ -21315,7 +21315,7 @@
       "kb_article": "KB5079466",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079466"
     },
     {
       "full_version": "10.0.26100.8039",
@@ -21327,7 +21327,7 @@
       "kb_article": "KB5085516",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5085516"
     },
     {
       "full_version": "10.0.26200.8039",
@@ -21339,7 +21339,7 @@
       "kb_article": "KB5085516",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5085516"
     },
     {
       "full_version": "10.0.26100.8116",
@@ -21351,7 +21351,7 @@
       "kb_article": "KB5079391",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079391"
     },
     {
       "full_version": "10.0.26200.8116",
@@ -21363,7 +21363,7 @@
       "kb_article": "KB5079391",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079391"
     },
     {
       "full_version": "10.0.28000.1764",
@@ -21375,7 +21375,7 @@
       "kb_article": "KB5079489",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5079489"
     },
     {
       "full_version": "10.0.26100.8117",
@@ -21387,7 +21387,7 @@
       "kb_article": "KB5086672",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5086672"
     },
     {
       "full_version": "10.0.26200.8117",
@@ -21399,7 +21399,7 @@
       "kb_article": "KB5086672",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5086672"
     },
     {
       "full_version": "10.0.14393.9060",
@@ -21411,7 +21411,7 @@
       "kb_article": "KB5082198",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082198"
     },
     {
       "full_version": "10.0.14393.9060",
@@ -21423,7 +21423,7 @@
       "kb_article": "KB5082198",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082198"
     },
     {
       "full_version": "10.0.17763.8644",
@@ -21435,7 +21435,7 @@
       "kb_article": "KB5082123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082123"
     },
     {
       "full_version": "10.0.17763.8644",
@@ -21447,7 +21447,7 @@
       "kb_article": "KB5082123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082123"
     },
     {
       "full_version": "10.0.19044.7184",
@@ -21459,7 +21459,7 @@
       "kb_article": "KB5082200",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082200"
     },
     {
       "full_version": "10.0.19045.7184",
@@ -21471,7 +21471,7 @@
       "kb_article": "KB5082200",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082200"
     },
     {
       "full_version": "10.0.20348.5020",
@@ -21483,7 +21483,7 @@
       "kb_article": "KB5082142",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082142"
     },
     {
       "full_version": "10.0.22631.6936",
@@ -21495,7 +21495,7 @@
       "kb_article": "KB5082052",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082052"
     },
     {
       "full_version": "10.0.25398.2274",
@@ -21507,7 +21507,7 @@
       "kb_article": "KB5082060",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082060"
     },
     {
       "full_version": "10.0.26100.32690",
@@ -21519,7 +21519,7 @@
       "kb_article": "KB5082063",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5082063"
     },
     {
       "full_version": "10.0.26100.8246",
@@ -21531,7 +21531,7 @@
       "kb_article": "KB5083769",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083769"
     },
     {
       "full_version": "10.0.26200.8246",
@@ -21543,7 +21543,7 @@
       "kb_article": "KB5083769",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083769"
     },
     {
       "full_version": "10.0.28000.1836",
@@ -21555,7 +21555,7 @@
       "kb_article": "KB5083768",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083768"
     },
     {
       "full_version": "10.0.14393.9062",
@@ -21567,7 +21567,7 @@
       "kb_article": "KB5091572",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091572"
     },
     {
       "full_version": "10.0.14393.9062",
@@ -21579,7 +21579,7 @@
       "kb_article": "KB5091572",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091572"
     },
     {
       "full_version": "10.0.17763.8647",
@@ -21591,7 +21591,7 @@
       "kb_article": "KB5091573",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091573"
     },
     {
       "full_version": "10.0.17763.8647",
@@ -21603,7 +21603,7 @@
       "kb_article": "KB5091573",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091573"
     },
     {
       "full_version": "10.0.20348.5024",
@@ -21615,7 +21615,7 @@
       "kb_article": "KB5091575",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091575"
     },
     {
       "full_version": "10.0.25398.2276",
@@ -21627,7 +21627,7 @@
       "kb_article": "KB5091571",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091571"
     },
     {
       "full_version": "10.0.26100.32698",
@@ -21639,7 +21639,7 @@
       "kb_article": "KB5091157",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5091157"
     },
     {
       "full_version": "10.0.26100.8328",
@@ -21651,7 +21651,7 @@
       "kb_article": "KB5083631",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083631"
     },
     {
       "full_version": "10.0.26200.8328",
@@ -21663,7 +21663,7 @@
       "kb_article": "KB5083631",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083631"
     },
     {
       "full_version": "10.0.28000.1896",
@@ -21675,7 +21675,7 @@
       "kb_article": "KB5083806",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5083806"
     },
     {
       "full_version": "10.0.14393.9140",
@@ -21687,7 +21687,7 @@
       "kb_article": "KB5087537",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087537"
     },
     {
       "full_version": "10.0.14393.9140",
@@ -21699,7 +21699,7 @@
       "kb_article": "KB5087537",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087537"
     },
     {
       "full_version": "10.0.17763.8755",
@@ -21711,7 +21711,7 @@
       "kb_article": "KB5087538",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087538"
     },
     {
       "full_version": "10.0.17763.8755",
@@ -21723,7 +21723,7 @@
       "kb_article": "KB5087538",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087538"
     },
     {
       "full_version": "10.0.19044.7291",
@@ -21735,7 +21735,7 @@
       "kb_article": "KB5087544",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087544"
     },
     {
       "full_version": "10.0.19045.7291",
@@ -21747,7 +21747,7 @@
       "kb_article": "KB5087544",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087544"
     },
     {
       "full_version": "10.0.20348.5139",
@@ -21759,7 +21759,7 @@
       "kb_article": "KB5087545",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087545"
     },
     {
       "full_version": "10.0.22631.7079",
@@ -21771,7 +21771,7 @@
       "kb_article": "KB5087420",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087420"
     },
     {
       "full_version": "10.0.25398.2330",
@@ -21783,7 +21783,7 @@
       "kb_article": "KB5087541",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087541"
     },
     {
       "full_version": "10.0.26100.32860",
@@ -21795,7 +21795,7 @@
       "kb_article": "KB5087539",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5087539"
     },
     {
       "full_version": "10.0.26100.8390",
@@ -21807,7 +21807,7 @@
       "kb_article": "KB5089466",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089466"
     },
     {
       "full_version": "10.0.26100.8457",
@@ -21819,7 +21819,7 @@
       "kb_article": "KB5089549",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089549"
     },
     {
       "full_version": "10.0.26200.8390",
@@ -21831,7 +21831,7 @@
       "kb_article": "KB5089466",
       "release_type": "Hotpatch",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089466"
     },
     {
       "full_version": "10.0.26200.8457",
@@ -21843,7 +21843,7 @@
       "kb_article": "KB5089549",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089549"
     },
     {
       "full_version": "10.0.28000.2113",
@@ -21855,7 +21855,7 @@
       "kb_article": "KB5089548",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089548"
     },
     {
       "full_version": "10.0.26100.8524",
@@ -21867,7 +21867,7 @@
       "kb_article": "KB5089573",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089573"
     },
     {
       "full_version": "10.0.26200.8524",
@@ -21879,7 +21879,7 @@
       "kb_article": "KB5089573",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089573"
     },
     {
       "full_version": "10.0.28000.2179",
@@ -21891,7 +21891,7 @@
       "kb_article": "KB5089570",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5089570"
     },
     {
       "full_version": "10.0.14393.9234",
@@ -21903,7 +21903,7 @@
       "kb_article": "KB5094122",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094122"
     },
     {
       "full_version": "10.0.14393.9234",
@@ -21915,7 +21915,7 @@
       "kb_article": "KB5094122",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094122"
     },
     {
       "full_version": "10.0.17763.8880",
@@ -21927,7 +21927,7 @@
       "kb_article": "KB5094123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094123"
     },
     {
       "full_version": "10.0.17763.8880",
@@ -21939,7 +21939,7 @@
       "kb_article": "KB5094123",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094123"
     },
     {
       "full_version": "10.0.19044.7417",
@@ -21951,7 +21951,7 @@
       "kb_article": "KB5094127",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094127"
     },
     {
       "full_version": "10.0.19045.7417",
@@ -21963,7 +21963,7 @@
       "kb_article": "KB5094127",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094127"
     },
     {
       "full_version": "10.0.20348.5256",
@@ -21975,7 +21975,7 @@
       "kb_article": "KB5094128",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094128"
     },
     {
       "full_version": "10.0.22631.7219",
@@ -21987,7 +21987,7 @@
       "kb_article": "KB5093998",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5093998"
     },
     {
       "full_version": "10.0.26100.32995",
@@ -21999,7 +21999,7 @@
       "kb_article": "KB5094125",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094125"
     },
     {
       "full_version": "10.0.26100.8655",
@@ -22011,7 +22011,7 @@
       "kb_article": "KB5094126",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094126"
     },
     {
       "full_version": "10.0.26200.8655",
@@ -22023,7 +22023,7 @@
       "kb_article": "KB5094126",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5094126"
     },
     {
       "full_version": "10.0.28000.2269",
@@ -22035,7 +22035,7 @@
       "kb_article": "KB5095051",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5095051"
     },
     {
       "full_version": "10.0.26100.8737",
@@ -22047,7 +22047,7 @@
       "kb_article": "KB5095093",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5095093"
     },
     {
       "full_version": "10.0.26200.8737",
@@ -22059,7 +22059,7 @@
       "kb_article": "KB5095093",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5095093"
     },
     {
       "full_version": "10.0.28000.2340",
@@ -22071,7 +22071,7 @@
       "kb_article": "KB5095091",
       "release_type": "Preview",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5095091"
     },
     {
       "full_version": "10.0.14393.9339",
@@ -22083,7 +22083,7 @@
       "kb_article": "KB5099535",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099535"
     },
     {
       "full_version": "10.0.14393.9339",
@@ -22095,7 +22095,7 @@
       "kb_article": "KB5099535",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099535"
     },
     {
       "full_version": "10.0.17763.9020",
@@ -22107,7 +22107,7 @@
       "kb_article": "KB5099538",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099538"
     },
     {
       "full_version": "10.0.17763.9020",
@@ -22119,7 +22119,7 @@
       "kb_article": "KB5099538",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099538"
     },
     {
       "full_version": "10.0.19044.7548",
@@ -22131,7 +22131,7 @@
       "kb_article": "KB5099539",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099539"
     },
     {
       "full_version": "10.0.19045.7548",
@@ -22143,7 +22143,7 @@
       "kb_article": "KB5099539",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099539"
     },
     {
       "full_version": "10.0.20348.5386",
@@ -22155,7 +22155,7 @@
       "kb_article": "KB5099540",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099540"
     },
     {
       "full_version": "10.0.22631.7376",
@@ -22167,7 +22167,7 @@
       "kb_article": "KB5099414",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099414"
     },
     {
       "full_version": "10.0.26100.33158",
@@ -22179,7 +22179,7 @@
       "kb_article": "KB5099536",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5099536"
     },
     {
       "full_version": "10.0.26100.8875",
@@ -22191,7 +22191,7 @@
       "kb_article": "KB5101650",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5101650"
     },
     {
       "full_version": "10.0.26200.8875",
@@ -22203,7 +22203,7 @@
       "kb_article": "KB5101650",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5101650"
     },
     {
       "full_version": "10.0.28000.2525",
@@ -22215,7 +22215,7 @@
       "kb_article": "KB5101649",
       "release_type": "Standard",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5101649"
     },
     {
       "full_version": "10.0.26100.8894",
@@ -22227,7 +22227,7 @@
       "kb_article": "KB5121767",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5121767"
     },
     {
       "full_version": "10.0.26200.8894",
@@ -22239,7 +22239,7 @@
       "kb_article": "KB5121767",
       "release_type": "Out-of-band",
       "is_expired": false,
-      "article_url": null
+      "article_url": "https://support.microsoft.com/help/5121767"
     }
   ]
 }

--- a/run.py
+++ b/run.py
@@ -43,7 +43,11 @@ def main() -> None:
 
     envelope = build_envelope(scraper, data)
     output_path = CONTENT_DIR / (scraper.dataset + ".json")
-    write_if_changed(output_path, envelope)
+    try:
+        write_if_changed(output_path, envelope)
+    except ScraperError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -15,3 +15,11 @@ class StructureChangedError(ParseError):
     This typically means the source site has been redesigned and the scraper
     needs to be updated.
     """
+
+
+class RecordCountDropError(ScraperError):
+    """Raised when a new dataset would shrink sharply versus the published one.
+
+    A large drop almost always means a partial parse failure (some sources
+    silently yielding zero records) rather than genuine upstream removal.
+    """

--- a/src/scrapers/ms/win_buildnumbers.py
+++ b/src/scrapers/ms/win_buildnumbers.py
@@ -10,7 +10,7 @@ from src.scrapers.base import BaseScraper
 from src.utils.scraper_helpers import (
     deduplicate_sorted,
     iter_versioned_tables,
-    normalize_ms_url,
+    kb_article_url,
     parse_date,
 )
 
@@ -122,7 +122,7 @@ def _parse_standard_page(
     fixed_major: int | None,
     category_filter: str | None = None,
 ) -> list[WinBuildNumber]:
-    """Parse a Windows update history page using the supLeftNavCategory nav structure.
+    """Parse a Windows update history page using the learnRenderLeftNavCategory nav structure.
 
     category_filter: if set, only process categories whose title contains this substring.
     Used for combined Win10+Server pages to isolate the server-specific section.
@@ -197,7 +197,7 @@ def _parse_standard_page(
             is_preview = "PREVIEW" in suffix_up or "PREVIEW" in desc_up
             release_type = "Out-of-band" if is_oob else "Preview" if is_preview else "Standard"
 
-            article_url = normalize_ms_url(str(a.get("href") or ""))
+            article_url = kb_article_url(kb_article)
 
             for version in [v.strip() for v in re.split(r"\s+and\s+|,", versions_raw) if v.strip()]:
                 records.append(
@@ -239,12 +239,10 @@ def _parse_hotpatch_page(html: str) -> list[WinBuildNumber]:
                 continue
 
             href_match = None
-            article_url = None
             for a in cell4.find_all("a", href=True):
                 hm = _HOTPATCH_HREF_RE.search(str(a["href"]))
                 if hm:
                     href_match = hm
-                    article_url = normalize_ms_url(str(a["href"]))
                     break
             if not href_match:
                 continue
@@ -255,6 +253,7 @@ def _parse_hotpatch_page(html: str) -> list[WinBuildNumber]:
             build1 = f"{href_match.group(4)}.{href_match.group(5)}"
             build2 = f"{href_match.group(6)}.{href_match.group(7)}"
             kb_article = kb_match.group(0).upper()
+            article_url = kb_article_url(kb_article)
 
             release_date = parse_date(f"{month_name} {day}, {year}")
             if not release_date:

--- a/src/utils/json_output.py
+++ b/src/utils/json_output.py
@@ -1,10 +1,19 @@
 """JSON envelope builder and write-if-changed output helper."""
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
+from src.exceptions import RecordCountDropError
 from src.scrapers.base import BaseScraper
+
+# Refuse to publish when the new record count falls below this fraction of the
+# previously published count. Guards against partial parse failures that leave
+# a non-empty (but gutted) record list — the failure mode that shipped a
+# 1,869 → 10 record collapse on 2026-07-14. Set ALLOW_RECORD_COUNT_DROP=1 to
+# override for intentional shrinkage (e.g. upstream removed a product line).
+_MIN_COUNT_RATIO = 0.9
 
 
 def build_envelope(scraper: BaseScraper, data: list[dict]) -> dict:
@@ -30,6 +39,7 @@ def write_if_changed(output_path: Path, envelope: dict) -> bool:
         if existing.get("data") == envelope.get("data"):
             print("No changes detected.")
             return False
+        _check_record_count_drop(existing, envelope, output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
         json.dumps(envelope, indent=2, ensure_ascii=False) + "\n",
@@ -37,3 +47,16 @@ def write_if_changed(output_path: Path, envelope: dict) -> bool:
     )
     print(f"Updated: {output_path}")
     return True
+
+
+def _check_record_count_drop(existing: dict, envelope: dict, output_path: Path) -> None:
+    if os.environ.get("ALLOW_RECORD_COUNT_DROP") == "1":
+        return
+    old_count = len(existing.get("data") or [])
+    new_count = len(envelope.get("data") or [])
+    if old_count > 0 and new_count < old_count * _MIN_COUNT_RATIO:
+        raise RecordCountDropError(
+            f"Refusing to write {output_path.name}: record count dropped from "
+            f"{old_count} to {new_count} (below {_MIN_COUNT_RATIO:.0%} threshold) — "
+            f"likely a partial parse failure. Set ALLOW_RECORD_COUNT_DROP=1 to override."
+        )

--- a/src/utils/scraper_helpers.py
+++ b/src/utils/scraper_helpers.py
@@ -80,6 +80,20 @@ def iter_versioned_tables(
         yield current_version, el
 
 
+def kb_article_url(kb_article: str) -> str | None:
+    """Return the canonical support.microsoft.com URL for a KB article.
+
+    Uses Microsoft's stable /help/<number> redirect service rather than page
+    hrefs, which are relative and change format with site redesigns (the
+    2026-07 redesign switched nav links to ../../-relative paths, nulling
+    every href-derived URL).
+    """
+    digits = kb_article.upper().removeprefix("KB")
+    if not digits.isdigit():
+        return None
+    return f"{_MS_SUPPORT_BASE}/help/{digits}"
+
+
 def normalize_ms_url(href: str, base: str = _MS_SUPPORT_BASE) -> str | None:
     """Return an absolute URL for a Microsoft support link.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,16 @@ from unittest.mock import MagicMock, call, patch
 import httpx
 import pytest
 
+from src.exceptions import RecordCountDropError
 from src.scrapers.base import BaseScraper
 from src.utils.http import _HEADERS, get_html
 from src.utils.json_output import build_envelope, write_if_changed
-from src.utils.scraper_helpers import deduplicate_sorted, normalize_ms_url, parse_date
+from src.utils.scraper_helpers import (
+    deduplicate_sorted,
+    kb_article_url,
+    normalize_ms_url,
+    parse_date,
+)
 
 # ---------------------------------------------------------------------------
 # http.py
@@ -183,6 +189,50 @@ def test_write_if_changed_overwrites_when_data_changed(tmp_path):
     assert written["data"] == [{"v": 2}]
 
 
+def test_write_if_changed_rejects_large_count_drop(tmp_path):
+    out = tmp_path / "out.json"
+    scraper = _FakeScraper()
+
+    write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(100)]))
+
+    with pytest.raises(RecordCountDropError, match="dropped from 100 to 10"):
+        write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(10)]))
+    # original file untouched
+    assert json.loads(out.read_text())["metadata"]["recordCount"] == 100
+
+
+def test_write_if_changed_allows_small_count_drop(tmp_path):
+    out = tmp_path / "out.json"
+    scraper = _FakeScraper()
+
+    write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(100)]))
+    result = write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(95)]))
+
+    assert result is True
+
+
+def test_write_if_changed_allows_count_growth(tmp_path):
+    out = tmp_path / "out.json"
+    scraper = _FakeScraper()
+
+    write_if_changed(out, build_envelope(scraper, [{"v": 1}]))
+    result = write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(50)]))
+
+    assert result is True
+
+
+def test_write_if_changed_count_drop_override(tmp_path, monkeypatch):
+    out = tmp_path / "out.json"
+    scraper = _FakeScraper()
+    monkeypatch.setenv("ALLOW_RECORD_COUNT_DROP", "1")
+
+    write_if_changed(out, build_envelope(scraper, [{"v": i} for i in range(100)]))
+    result = write_if_changed(out, build_envelope(scraper, [{"v": 1}]))
+
+    assert result is True
+    assert json.loads(out.read_text())["metadata"]["recordCount"] == 1
+
+
 def test_build_envelope_structure():
     scraper = _FakeScraper()
     data = [{"a": 1}]
@@ -268,3 +318,16 @@ def test_normalize_ms_url_empty_returns_none():
 
 def test_normalize_ms_url_unrecognised_returns_none():
     assert normalize_ms_url("javascript:void(0)") is None
+
+
+def test_kb_article_url_standard():
+    assert kb_article_url("KB5099539") == "https://support.microsoft.com/help/5099539"
+
+
+def test_kb_article_url_lowercase_prefix():
+    assert kb_article_url("kb5099539") == "https://support.microsoft.com/help/5099539"
+
+
+def test_kb_article_url_invalid_returns_none():
+    assert kb_article_url("KBabc") is None
+    assert kb_article_url("") is None

--- a/tests/test_win_buildnumbers.py
+++ b/tests/test_win_buildnumbers.py
@@ -122,6 +122,13 @@ class TestParseStandardPage:
         for r in _parse_standard_page(win10_html, os_type="client", fixed_major=10):
             assert isinstance(r.is_expired, bool)
 
+    def test_article_url_never_null(self, win10_html):
+        # Regression guard: the 2026-07 site redesign switched hrefs to relative
+        # paths, silently nulling every href-derived article_url.
+        for r in _parse_standard_page(win10_html, os_type="client", fixed_major=10):
+            assert r.article_url is not None
+            assert r.article_url == f"https://support.microsoft.com/help/{r.kb_article[2:]}"
+
     def test_win11_page_parses(self, win11_html):
         records = _parse_standard_page(win11_html, os_type="client", fixed_major=11)
         assert len(records) > 50
@@ -230,6 +237,10 @@ class TestWinBuildNumbersScraper:
         records = WinBuildNumbersScraper().parse(all_pages)
         hotpatch = [r for r in records if r["release_type"] in {"Hotpatch", "Hotpatch-OOB"}]
         assert len(hotpatch) > 0
+
+    def test_all_article_urls_populated(self, all_pages):
+        records = WinBuildNumbersScraper().parse(all_pages)
+        assert all(r["article_url"] for r in records)
 
     def test_os_types_present(self, all_pages):
         records = WinBuildNumbersScraper().parse(all_pages)


### PR DESCRIPTION
## Summary
Two hardening changes from the post-incident review (follow-up to #301):

**1. Record-count drop guard (protects all 19 datasets).** `write_if_changed` now refuses to publish when the new record count falls below 90% of the previously published count, raising `RecordCountDropError` (exit 1, so the workflow fails before any PR is created). The previous envelope was already being parsed there — the old count just was never compared. This converts the failure class that shipped the 1,869 → 10 collapse in #296 into a loud failure. Intentional shrinkage can be forced with `ALLOW_RECORD_COUNT_DROP=1`.

**2. `article_url` no longer null.** After the 2026-07 redesign, nav hrefs became `../../`-relative, which `normalize_ms_url` returns `None` for — so #301 shipped 1,852/1,852 records with `article_url: null`. URLs are now derived from the KB number via Microsoft's stable `/help/<number>` redirect (new `kb_article_url` helper), removing the href-format dependency entirely. Verified the redirect resolves for KBs from 2016 through 2026, including the 5 current hotpatch KBs — hotpatch rows previously had null URLs even in healthy data, so this is a strict improvement. Regenerated `buildnumbers.json`: 1,852 records, 0 nulls.

Also fixes the stale `supLeftNavCategory` docstring reference.

## Test plan
- [x] 4 new tests for the count guard (reject >10% drop, allow small drop, allow growth, env override)
- [x] 3 new tests for `kb_article_url`; 2 new regression tests asserting no null `article_url` in scraper output
- [x] Full suite: 217 passed; ruff clean
- [x] Live regeneration confirms 1,852 records, 0 null `article_url`, count guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)