### PR TITLE
Fix three dataset-completeness gaps; harden M365 channel parsing

### DIFF
--- a/content/ms/other/asr-guids.json
+++ b/content/ms/other/asr-guids.json
@@ -3,12 +3,12 @@
     "provider": "DataForGeeks",
     "apiVersion": "v2",
     "dataset": "asr-guids",
-    "recordCount": 18,
+    "recordCount": 19,
     "sourceUrls": [
       "https://learn.microsoft.com/en-us/defender-endpoint/attack-surface-reduction-rules-reference"
     ],
-    "lastModified": "2026-05-28T02:09:15Z",
-    "lastCollected": "2026-05-28T02:09:15Z"
+    "lastModified": "2026-07-22T17:41:55Z",
+    "lastCollected": "2026-07-22T17:41:55Z"
   },
   "data": [
     {
@@ -66,6 +66,10 @@
     {
       "asr_name": "Block use of copied or impersonated system tools",
       "asr_guid": "c0033c00-d16d-4114-a5a0-dc9b3a7d2ceb"
+    },
+    {
+      "asr_name": "Use advanced protection against ransomware",
+      "asr_guid": "c1db55ab-c21a-4637-bb3f-a12568109d35"
     },
     {
       "asr_name": "Block process creations originating from PSExec and WMI commands",

--- a/content/ms/win/lifecycle-ltsc.json
+++ b/content/ms/win/lifecycle-ltsc.json
@@ -3,12 +3,13 @@
     "provider": "DataForGeeks",
     "apiVersion": "v2",
     "dataset": "windows-lifecycle-ltsc",
-    "recordCount": 3,
+    "recordCount": 4,
     "sourceUrls": [
-      "https://learn.microsoft.com/en-us/windows/release-health/release-information"
+      "https://learn.microsoft.com/en-us/windows/release-health/release-information",
+      "https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information"
     ],
-    "lastModified": "2026-05-28T02:09:30Z",
-    "lastCollected": "2026-05-28T02:09:30Z"
+    "lastModified": "2026-07-22T17:41:51Z",
+    "lastCollected": "2026-07-22T17:41:51Z"
   },
   "data": [
     {
@@ -34,6 +35,14 @@
       "start_date": "2021-11-16",
       "mainstream_end_date": "2027-01-12",
       "extended_end_date": "2032-01-13"
+    },
+    {
+      "version": "24H2",
+      "servicing_option": "Long-Term Servicing Channel (LTSC)",
+      "build": "26100",
+      "start_date": "2024-10-01",
+      "mainstream_end_date": "2029-10-09",
+      "extended_end_date": "2034-10-10"
     }
   ]
 }

--- a/content/ms/win/lifecycle-server.json
+++ b/content/ms/win/lifecycle-server.json
@@ -3,7 +3,7 @@
     "provider": "DataForGeeks",
     "apiVersion": "v2",
     "dataset": "windows-lifecycle-server",
-    "recordCount": 8,
+    "recordCount": 28,
     "sourceUrls": [
       "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008",
       "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2",
@@ -14,15 +14,99 @@
       "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022",
       "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2025"
     ],
-    "lastModified": "2026-05-28T02:09:35Z",
-    "lastCollected": "2026-05-28T02:09:35Z"
+    "lastModified": "2026-07-22T17:41:54Z",
+    "lastCollected": "2026-07-22T17:41:54Z"
   },
   "data": [
+    {
+      "version": "Windows Server 2008",
+      "tier": "Extended Security Update Year 1",
+      "start_date": "2020-01-15",
+      "mainstream_end_date": "2021-01-12",
+      "extended_end_date": "2021-01-12"
+    },
+    {
+      "version": "Windows Server 2008",
+      "tier": "Extended Security Update Year 2",
+      "start_date": "2021-01-13",
+      "mainstream_end_date": "2022-01-11",
+      "extended_end_date": "2022-01-11"
+    },
+    {
+      "version": "Windows Server 2008",
+      "tier": "Extended Security Update Year 3",
+      "start_date": "2022-01-12",
+      "mainstream_end_date": "2023-01-10",
+      "extended_end_date": "2023-01-10"
+    },
+    {
+      "version": "Windows Server 2008",
+      "tier": "Extended Security Update Year 4 (Azure only)",
+      "start_date": "2023-01-11",
+      "mainstream_end_date": "2024-01-09",
+      "extended_end_date": "2024-01-09"
+    },
+    {
+      "version": "Windows Server 2008",
+      "tier": "Original Release",
+      "start_date": "2008-05-06",
+      "mainstream_end_date": "2011-07-12",
+      "extended_end_date": "2011-07-12"
+    },
+    {
+      "version": "Windows Server 2008",
+      "tier": "Service Pack 2",
+      "start_date": "2009-04-29",
+      "mainstream_end_date": "2020-01-14",
+      "extended_end_date": "2020-01-14"
+    },
     {
       "version": "Windows Server 2008",
       "tier": "Windows Server 2008",
       "start_date": "2008-05-06",
       "mainstream_end_date": "2015-01-13",
+      "extended_end_date": "2020-01-14"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Extended Security Update Year 1",
+      "start_date": "2020-01-15",
+      "mainstream_end_date": "2021-01-12",
+      "extended_end_date": "2021-01-12"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Extended Security Update Year 2",
+      "start_date": "2021-01-13",
+      "mainstream_end_date": "2022-01-11",
+      "extended_end_date": "2022-01-11"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Extended Security Update Year 3",
+      "start_date": "2022-01-12",
+      "mainstream_end_date": "2023-01-10",
+      "extended_end_date": "2023-01-10"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Extended Security Update Year 4 (Azure only)",
+      "start_date": "2023-01-11",
+      "mainstream_end_date": "2024-01-09",
+      "extended_end_date": "2024-01-09"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Original Release",
+      "start_date": "2009-10-22",
+      "mainstream_end_date": "2013-04-09",
+      "extended_end_date": "2013-04-09"
+    },
+    {
+      "version": "Windows Server 2008 R2",
+      "tier": "Service Pack 1",
+      "start_date": "2011-02-22",
+      "mainstream_end_date": "2020-01-14",
       "extended_end_date": "2020-01-14"
     },
     {
@@ -34,9 +118,65 @@
     },
     {
       "version": "Windows Server 2012",
+      "tier": "Extended Security Update Year 1",
+      "start_date": "2023-10-11",
+      "mainstream_end_date": "2024-10-08",
+      "extended_end_date": "2024-10-08"
+    },
+    {
+      "version": "Windows Server 2012",
+      "tier": "Extended Security Update Year 2",
+      "start_date": "2024-10-09",
+      "mainstream_end_date": "2025-10-14",
+      "extended_end_date": "2025-10-14"
+    },
+    {
+      "version": "Windows Server 2012",
+      "tier": "Extended Security Update Year 3",
+      "start_date": "2025-10-15",
+      "mainstream_end_date": "2026-10-13",
+      "extended_end_date": "2026-10-13"
+    },
+    {
+      "version": "Windows Server 2012",
+      "tier": "Original Release",
+      "start_date": "2012-10-30",
+      "mainstream_end_date": "2023-10-10",
+      "extended_end_date": "2023-10-10"
+    },
+    {
+      "version": "Windows Server 2012",
       "tier": "Windows Server 2012",
       "start_date": "2012-10-30",
       "mainstream_end_date": "2018-10-09",
+      "extended_end_date": "2023-10-10"
+    },
+    {
+      "version": "Windows Server 2012 R2",
+      "tier": "Extended Security Update Year 1",
+      "start_date": "2023-10-11",
+      "mainstream_end_date": "2024-10-08",
+      "extended_end_date": "2024-10-08"
+    },
+    {
+      "version": "Windows Server 2012 R2",
+      "tier": "Extended Security Update Year 2",
+      "start_date": "2024-10-09",
+      "mainstream_end_date": "2025-10-14",
+      "extended_end_date": "2025-10-14"
+    },
+    {
+      "version": "Windows Server 2012 R2",
+      "tier": "Extended Security Update Year 3",
+      "start_date": "2025-10-15",
+      "mainstream_end_date": "2026-10-13",
+      "extended_end_date": "2026-10-13"
+    },
+    {
+      "version": "Windows Server 2012 R2",
+      "tier": "Original Release",
+      "start_date": "2013-11-25",
+      "mainstream_end_date": "2023-10-10",
       "extended_end_date": "2023-10-10"
     },
     {

--- a/src/scrapers/ms/asr_guids.py
+++ b/src/scrapers/ms/asr_guids.py
@@ -27,26 +27,39 @@ class AsrGuidsScraper(BaseScraper):
 
         # Each rule section uses an <h4> heading followed by a <ul> that
         # contains a <li> with <strong>GUID</strong>: <code>uuid</code>.
+        # The GUID <ul> is not always the first list in the section — some
+        # rules (e.g. "Use advanced protection against ransomware") have a
+        # descriptive bullet list first — so scan every <ul> sibling up to
+        # the next heading.
         records: list[AsrGuid] = []
         for h4 in soup.find_all("h4"):
             rule_name = h4.get_text(strip=True)
 
-            ul = h4.find_next_sibling("ul")
-            if ul is None:
-                continue
-
-            for li in ul.find_all("li", recursive=False):
-                strong = li.find("strong")
-                if strong and strong.get_text(strip=True) == "GUID":
-                    code = li.find("code")
-                    if code:
-                        guid = code.get_text(strip=True).lower()
-                        if _UUID_RE.fullmatch(guid):
-                            records.append(AsrGuid(asr_name=rule_name, asr_guid=guid))
-                    break
+            guid = _find_section_guid(h4)
+            if guid:
+                records.append(AsrGuid(asr_name=rule_name, asr_guid=guid))
 
         if not records:
             raise StructureChangedError("No ASR GUID entries parsed — page structure may have changed")
 
         unique = deduplicate_sorted(records, sort_key=lambda r: r.asr_guid)
         return [r.model_dump() for r in unique]
+
+
+def _find_section_guid(heading) -> str | None:
+    """Return the GUID from the first <strong>GUID</strong> list item between
+    *heading* and the next heading, or None if the section has no GUID."""
+    sib = heading.find_next_sibling()
+    while sib is not None and sib.name not in ("h2", "h3", "h4"):
+        if sib.name == "ul":
+            for li in sib.find_all("li", recursive=False):
+                strong = li.find("strong")
+                if strong and strong.get_text(strip=True) == "GUID":
+                    code = li.find("code")
+                    if code:
+                        guid = code.get_text(strip=True).lower()
+                        if _UUID_RE.fullmatch(guid):
+                            return guid
+                    return None
+        sib = sib.find_next_sibling()
+    return None

--- a/src/scrapers/ms/m365_buildnumbers.py
+++ b/src/scrapers/ms/m365_buildnumbers.py
@@ -12,11 +12,14 @@ _SOURCE_URL = "https://learn.microsoft.com/en-us/officeupdates/update-history-mi
 
 _VERSION_BUILD_RE = re.compile(r"Version\s+(\S+)\s+\(Build\s+([^)]+)\)", re.IGNORECASE)
 
-_CHANNELS = {
-    2: "Current",
-    3: "Monthly Enterprise",
-    4: "Semi-Annual Enterprise Preview",
-    5: "Semi-Annual Enterprise",
+# Header text → channel label. Column positions are derived from the header
+# row at parse time so a column insertion or reorder cannot silently
+# mislabel channels.
+_CHANNEL_HEADERS = {
+    "Current Channel": "Current",
+    "Monthly Enterprise Channel": "Monthly Enterprise",
+    "Semi-Annual Enterprise Channel (Preview)": "Semi-Annual Enterprise Preview",
+    "Semi-Annual Enterprise Channel": "Semi-Annual Enterprise",
 }
 
 
@@ -30,26 +33,29 @@ class M365BuildNumbersScraper(BaseScraper):
     def parse(self, pages: dict[str, str]) -> list[dict]:
         soup = BeautifulSoup(pages[_SOURCE_URL], "lxml")
 
-        tables = soup.find_all("table")
-        if len(tables) < 2:
-            raise StructureChangedError(
-                f"Expected at least 2 tables, found {len(tables)} — page structure may have changed"
-            )
+        history_table, columns = _find_history_table(soup)
 
-        # Table at index 1: Year | Date | Current | Monthly Enterprise | SAEP | SAE
+        year_idx = columns["Year"]
+        date_idx = columns["Release Date"]
+        channel_cols = {
+            idx: _CHANNEL_HEADERS[header]
+            for header, idx in columns.items()
+            if header in _CHANNEL_HEADERS
+        }
+
         records: list[M365Build] = []
         last_year = ""
 
-        for row in tables[1].find_all("tr"):
+        for row in history_table.find_all("tr"):
             cells = row.find_all("td")
-            if len(cells) < 6:
+            if len(cells) <= max(channel_cols):
                 continue
 
-            year_text = cells[0].get_text(strip=True)
+            year_text = cells[year_idx].get_text(strip=True)
             year = year_text if year_text else last_year
             last_year = year
 
-            date_text = cells[1].get_text(separator=" ", strip=True)
+            date_text = cells[date_idx].get_text(separator=" ", strip=True)
             # Remove any <br>-introduced whitespace artifacts
             date_text = re.sub(r"\s+", " ", date_text).strip()
 
@@ -58,7 +64,7 @@ class M365BuildNumbersScraper(BaseScraper):
             except ValueError:
                 continue
 
-            for col_idx, channel_name in _CHANNELS.items():
+            for col_idx, channel_name in channel_cols.items():
                 cell_text = cells[col_idx].get_text(separator=" ", strip=True)
                 for m in _VERSION_BUILD_RE.finditer(cell_text):
                     version = m.group(1).strip()
@@ -78,3 +84,25 @@ class M365BuildNumbersScraper(BaseScraper):
 
         unique = deduplicate_sorted(records, sort_key=lambda r: r.release_date, key_fn=lambda r: (r.release_date, r.channel, r.build), reverse=True)
         return [r.model_dump() for r in unique]
+
+
+def _find_history_table(soup) -> tuple:
+    """Locate the release-history table by its header row and return it with a
+    {header text: column index} map. Raises StructureChangedError when no table
+    carries the expected Year / Release Date / channel headers."""
+    for table in soup.find_all("table"):
+        header_row = table.find("tr")
+        if header_row is None:
+            continue
+        headers = [c.get_text(strip=True) for c in header_row.find_all(["th", "td"])]
+        columns = {h: i for i, h in enumerate(headers)}
+        if "Year" not in columns or "Release Date" not in columns:
+            continue
+        matched = [h for h in headers if h in _CHANNEL_HEADERS]
+        if len(matched) != len(_CHANNEL_HEADERS):
+            raise StructureChangedError(
+                f"History table channel columns changed: expected {sorted(_CHANNEL_HEADERS)}, "
+                f"found {matched} — page structure may have changed"
+            )
+        return table, columns
+    raise StructureChangedError("Release-history table not found — page structure may have changed")

--- a/src/scrapers/ms/win_lifecycle_ltsc.py
+++ b/src/scrapers/ms/win_lifecycle_ltsc.py
@@ -5,64 +5,80 @@ from src.models.ms.win_lifecycle_ltsc import WinLifecycleLtsc
 from src.scrapers.base import BaseScraper
 from src.utils.scraper_helpers import deduplicate_sorted
 
-_SOURCE_URL = "https://learn.microsoft.com/en-us/windows/release-health/release-information"
+_WIN10_URL = "https://learn.microsoft.com/en-us/windows/release-health/release-information"
+_WIN11_URL = "https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information"
 
 
 class WinLifecycleLtscScraper(BaseScraper):
-    """Scrapes Windows LTSC build and lifecycle data from the release health page on learn.microsoft.com."""
+    """Scrapes Windows LTSC build and lifecycle data from the release health pages on learn.microsoft.com."""
 
     dataset = "ms/win/lifecycle-ltsc"
     dataset_name = "windows-lifecycle-ltsc"
-    sources = [_SOURCE_URL]
+    sources = [_WIN10_URL, _WIN11_URL]
 
     def parse(self, pages: dict[str, str]) -> list[dict]:
-        soup = BeautifulSoup(pages[_SOURCE_URL], "lxml")
-
-        # Find the table that contains "Long-Term Servicing" text
-        ltsc_table = None
-        for table in soup.find_all("table"):
-            if "Long-Term Servicing" in table.get_text():
-                ltsc_table = table
-                break
-
-        if ltsc_table is None:
-            raise StructureChangedError("LTSC summary table not found — page structure may have changed")
-
         records: list[WinLifecycleLtsc] = []
-        for row in ltsc_table.find_all("tr"):
-            cells = row.find_all(["td", "th"])
-            if len(cells) != 8:
-                continue
-
-            # Table columns: Version | Servicing Option | Start | Mainstream End |
-            #   Extended End | (unused) | (unused) | Latest Build
-            version = cells[0].get_text(strip=True)
-            if not version or version.lower() == "version":
-                continue
-
-            servicing_option = cells[1].get_text(strip=True)
-            start_date = cells[2].get_text(strip=True)
-            mainstream_end = cells[3].get_text(strip=True)
-            # col 4 may have trailing text after the date; take the first token
-            extended_raw = cells[4].get_text(strip=True)
-            extended_end = extended_raw.split()[0] if extended_raw else ""
-            # col 7: latest build as "NNNNN.XXXX"; keep only the base build (before the dot)
-            latest_build_text = cells[7].get_text(strip=True)
-            build = latest_build_text.partition(".")[0] if latest_build_text else ""
-
-            records.append(
-                WinLifecycleLtsc(
-                    version=version,
-                    servicing_option=servicing_option,
-                    build=build,
-                    start_date=start_date,
-                    mainstream_end_date=mainstream_end,
-                    extended_end_date=extended_end,
-                )
-            )
+        records.extend(_parse_ltsc_page(pages[_WIN10_URL], page_label="Windows 10"))
+        records.extend(_parse_ltsc_page(pages[_WIN11_URL], page_label="Windows 11"))
 
         if not records:
             raise StructureChangedError("No LTSC entries parsed — page structure may have changed")
 
         unique = deduplicate_sorted(records, sort_key=lambda r: r.version)
         return [r.model_dump() for r in unique]
+
+
+def _parse_ltsc_page(html: str, page_label: str) -> list[WinLifecycleLtsc]:
+    soup = BeautifulSoup(html, "lxml")
+
+    # Find the table that contains "Long-Term Servicing" text
+    ltsc_table = None
+    for table in soup.find_all("table"):
+        if "Long-Term Servicing" in table.get_text():
+            ltsc_table = table
+            break
+
+    if ltsc_table is None:
+        raise StructureChangedError(
+            f"LTSC summary table not found on {page_label} page — page structure may have changed"
+        )
+
+    records: list[WinLifecycleLtsc] = []
+    for row in ltsc_table.find_all("tr"):
+        # Footnote markers render as <sup> inside cells (e.g. "24H2<sup>1</sup>");
+        # drop them before text extraction.
+        for sup in row.find_all("sup"):
+            sup.decompose()
+
+        cells = row.find_all(["td", "th"])
+        if len(cells) != 8:
+            continue
+
+        # Table columns: Version | Servicing Option | Start | Mainstream End |
+        #   Extended End | (unused) | (unused) | Latest Build
+        version = cells[0].get_text(strip=True)
+        if not version or version.lower() == "version":
+            continue
+
+        servicing_option = cells[1].get_text(strip=True)
+        start_date = cells[2].get_text(strip=True)
+        mainstream_end = cells[3].get_text(strip=True)
+        # col 4 may have trailing text after the date; take the first token
+        extended_raw = cells[4].get_text(strip=True)
+        extended_end = extended_raw.split()[0] if extended_raw else ""
+        # col 7: latest build as "NNNNN.XXXX"; keep only the base build (before the dot)
+        latest_build_text = cells[7].get_text(strip=True)
+        build = latest_build_text.partition(".")[0] if latest_build_text else ""
+
+        records.append(
+            WinLifecycleLtsc(
+                version=version,
+                servicing_option=servicing_option,
+                build=build,
+                start_date=start_date,
+                mainstream_end_date=mainstream_end,
+                extended_end_date=extended_end,
+            )
+        )
+
+    return records

--- a/src/scrapers/ms/win_lifecycle_server.py
+++ b/src/scrapers/ms/win_lifecycle_server.py
@@ -18,7 +18,15 @@ _SOURCES = [
 
 
 class WinLifecycleServerScraper(BaseScraper):
-    """Scrapes Windows Server lifecycle dates from individual product pages on learn.microsoft.com."""
+    """Scrapes Windows Server lifecycle dates from individual product pages on learn.microsoft.com.
+
+    Each product page has two tables:
+    - a "Listing" table with the product's overall start / mainstream end /
+      extended end dates (one row, three <local-time> elements), and
+    - a "Version | Start Date | End Date" releases table with per-tier rows
+      (Service Packs, Extended Security Update years, Original Release —
+      two <local-time> elements each).
+    """
 
     dataset = "ms/win/lifecycle-server"
     dataset_name = "windows-lifecycle-server"
@@ -35,26 +43,43 @@ class WinLifecycleServerScraper(BaseScraper):
 
             for row in soup.find_all("tr"):
                 cells = row.find_all("td")
-                if len(cells) < 4:
-                    continue
-
-                tier = cells[0].get_text(strip=True)
                 local_times = row.find_all("local-time")
-                if len(local_times) < 3:
-                    continue
 
-                records.append(
-                    WinLifecycleServer(
-                        version=version,
-                        tier=tier,
-                        start_date=str(local_times[0].get("datetime") or "")[:10],
-                        mainstream_end_date=str(local_times[1].get("datetime") or "")[:10],
-                        extended_end_date=str(local_times[2].get("datetime") or "")[:10],
+                if len(cells) >= 4 and len(local_times) >= 3:
+                    # Listing table: product row with all three lifecycle dates.
+                    records.append(
+                        WinLifecycleServer(
+                            version=version,
+                            tier=cells[0].get_text(strip=True),
+                            start_date=_lt_date(local_times[0]),
+                            mainstream_end_date=_lt_date(local_times[1]),
+                            extended_end_date=_lt_date(local_times[2]),
+                        )
                     )
-                )
+                elif len(cells) == 3 and len(local_times) == 2:
+                    # Releases table: tier row (SP / ESU year / Original Release)
+                    # with only start and end dates. The end date is when all
+                    # support for the tier stops, so it fills both end fields.
+                    tier = cells[0].get_text(strip=True)
+                    if not tier:
+                        continue
+                    end_date = _lt_date(local_times[1])
+                    records.append(
+                        WinLifecycleServer(
+                            version=version,
+                            tier=tier,
+                            start_date=_lt_date(local_times[0]),
+                            mainstream_end_date=end_date,
+                            extended_end_date=end_date,
+                        )
+                    )
 
         if not records:
             raise StructureChangedError("No server lifecycle entries parsed — page structure may have changed")
 
         unique = deduplicate_sorted(records, sort_key=lambda r: (r.version, r.tier))
         return [r.model_dump() for r in unique]
+
+
+def _lt_date(local_time) -> str:
+    return str(local_time.get("datetime") or "")[:10]

--- a/tests/fixtures/ms/asr_guids.html
+++ b/tests/fixtures/ms/asr_guids.html
@@ -74,7 +74,7 @@
 	
 		<meta name="ms.collection" content="mde-asr" />
 	
-		<meta name="ms.date" content="2026-05-04T00:00:00Z" />
+		<meta name="ms.date" content="2026-07-02T00:00:00Z" />
 	
 		<meta name="search.appverid" content="met150" />
 	
@@ -84,13 +84,13 @@
 	
 		<meta name="document_version_independent_id" content="340a0f8c-90ef-f5e9-a860-48c1651c86bf" />
 	
-		<meta name="updated_at" content="2026-05-22T07:35:00Z" />
+		<meta name="updated_at" content="2026-07-17T07:34:00Z" />
 	
 		<meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/defender-docs-pr/blob/live/defender-endpoint/attack-surface-reduction-rules-reference.md" />
 	
-		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/defender-docs-pr/blob/6fc4d32adae7d72249c08de08ce6d36acd92c674/defender-endpoint/attack-surface-reduction-rules-reference.md" />
+		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/defender-docs-pr/blob/533bc0b99c0c54dde75b72e4d0fc952467530e4e/defender-endpoint/attack-surface-reduction-rules-reference.md" />
 	
-		<meta name="git_commit_id" content="6fc4d32adae7d72249c08de08ce6d36acd92c674" />
+		<meta name="git_commit_id" content="533bc0b99c0c54dde75b72e4d0fc952467530e4e" />
 	
 		<meta name="site_name" content="Docs" />
 	
@@ -104,7 +104,7 @@
 	
 		<meta name="feedback_help_link_url" content="" />
 	
-		<meta name="word_count" content="4602" />
+		<meta name="word_count" content="4468" />
 	
 		<meta name="asset_id" content="attack-surface-reduction-rules-reference" />
 	
@@ -114,7 +114,7 @@
 	
 		<meta name="source_path" content="defender-endpoint/attack-surface-reduction-rules-reference.md" />
 	
-		<meta name="previous_tlsh_hash" content="26A3E3E2C81B47169F92571B9437B14423A1C189FAE13AC0021A698BC0551E6257EC10EEF747A3B6B36B178352C3DE9AB5A3EF3F826D1313069030BEC06D9A8777C93BB5F6" />
+		<meta name="previous_tlsh_hash" content="9EFE34D2B81B47169F92471BD437B14423A5C189FAE13AC0021A5987C0552E625BEC10EEE747A3B6B36B178352C3DE9AB5A3EF3F826D1353069030BEC06D9A8777C93BB5F6" />
 	
 		<meta name="github_feedback_content_git_url" content="https://github.com/MicrosoftDocs/defender-docs/blob/public/defender-endpoint/attack-surface-reduction-rules-reference.md" />
 	
@@ -125,13 +125,52 @@
 		<meta name="spProducts" content="https://authoring-docs-microsoft.poolparty.biz/devrel/f3a81ffb-ee36-4ec7-b54a-01b6681aff65" data-source="generated" />
 	
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -151,6 +190,7 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Conceptual",
+    "layoutStateStorageKey": "docs-layout-persistence",
     "brand": "",
     "context": {},
     "standardFeedback": true,
@@ -234,7 +274,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -345,7 +388,7 @@
 					
 		<div
 			id="left-container"
-			class="left-container display-none padding-none display-block-tablet width-full"
+			class="left-container display-none padding-none display-block-tablet width-full display-none-until-layout-restored"
 			data-toc-container="true"
 		>
 			<div
@@ -368,11 +411,17 @@
 							class="button button-clear inner-focus"
 							data-collapsible-toc-toggle
 							aria-expanded="true"
+							hidden
 							aria-controls="ms--toc-content"
 							aria-label="Table of contents"
 						>
 							<span class="icon icon-mirrored-rtl font-size-md" aria-hidden="true">
-								<span class="docon docon-panel-left-contract"></span>
+								<span
+									class="docon docon-panel-left-contract display-none-layout-menu-collapsed"
+								></span>
+								<span
+									class="docon docon-panel-left-expand display-none display-inline-layout-menu-collapsed"
+								></span>
 							</span>
 						</button>
 						<div
@@ -542,7 +591,7 @@
 		<button
 			data-page-action-item="overflow-mobile"
 			type="button"
-			class="button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
+			class="display-block-layout-menu-collapsed button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
 			data-bi-name="contents-expand"
 			data-contents-button
 			data-popover-close
@@ -598,7 +647,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -1035,7 +1084,7 @@
 <td style="text-align: center;">Y</td>
 </tr>
 <tr>
-<td>Block executable files from running unless they meet a prevalence, age, or trusted list criterion[<a href="#CMS1" data-linktype="self-bookmark">1</a>]</td>
+<td>Block executable files from running unless they meet a prevalence, age, or trusted list criterion</td>
 <td style="text-align: center;">Y</td>
 <td style="text-align: center;">1802 or later</td>
 <td style="text-align: center;">Y</td>
@@ -1129,9 +1178,9 @@
 </table>
 <div class="TIP">
 <p>Tip</p>
-<p>You can also configure ASR rules locally on individual devices using Group Policy or <a href="attack-surface-reduction-rules-configure#configure-asr-rules-in-powershell" data-linktype="relative-path">PowerShell</a>. All ASR rules are supported by both methods on local devices.</p>
+<p>The Microsoft Defender portal uses the <a href="endpoint-security-policies-configure" data-linktype="relative-path">same endpoint security policies as Intune</a>, so it supports the same rules shown in the <strong>Intune</strong> column.</p>
+<p>You can also configure ASR rules locally on individual devices using <a href="attack-surface-reduction-rules-configure#configure-asr-rules-and-exclusions-in-group-policy" data-linktype="relative-path">Group Policy</a> or <a href="attack-surface-reduction-rules-configure#configure-asr-rules-in-powershell" data-linktype="relative-path">PowerShell</a>. All ASR rules are supported by both methods on local devices.</p>
 </div>
-<p><a id="CMS1">1</a> Currently, this ASR rule might not be available in the Intune ASR policy configuration due to a known backend issue. But, the rule is available through the other available ASR policy configuration methods or in existing Intune ASR policies created before the issue.</p>
 <p><a name="per-asr-rule-alert-and-notification-details"></a></p>
 <h2 id="alerts-and-notifications-from-asr-rule-actions">Alerts and notifications from ASR rule actions</h2>
 <p>The following table describes the organization and local alerts that active ASR rules can generate.</p>
@@ -1460,10 +1509,6 @@
 </ul>
 </div>
 <h4 id="block-executable-files-from-running-unless-they-meet-a-prevalence-age-or-trusted-list-criterion">Block executable files from running unless they meet a prevalence, age, or trusted list criterion</h4>
-<div class="TIP">
-<p>Tip</p>
-<p>Currently, this ASR rule might not be available in the Intune ASR policy configuration due to a known backend issue. But, the rule is available through the <a href="attack-surface-reduction-rules-configure" data-linktype="relative-path">other available ASR policy configuration methods</a> or in existing Intune ASR policies created before the issue.</p>
-</div>
 <p>This ASR rule blocks executable files (for example, .exe, .dll, or .scr, from launching). Launching untrusted or unknown executable files can be risky, as it's not initially clear if the files are malicious.</p>
 <ul>
 <li><strong>Microsoft Intune name</strong>: <code>Block executable files from running unless they meet a prevalence, age, or trusted list criterion</code></li>
@@ -1656,10 +1701,6 @@
 </li>
 <li><strong>Dependencies</strong>: Microsoft Defender Antivirus</li>
 </ul>
-<div class="NOTE">
-<p>Note</p>
-<p>Currently, Microsoft Defender Vulnerability Management doesn't recognize this rule. The <a href="attack-surface-reduction-rules-report" data-linktype="relative-path">Attack surface reduction (ASR) rules report</a> shows this rule as <strong>Not applicable</strong>.</p>
-</div>
 <h4 id="block-untrusted-and-unsigned-processes-that-run-from-usb">Block untrusted and unsigned processes that run from USB</h4>
 <p>This ASR rule prevents unsigned or untrusted executable files (for example, .exe, .dll, or .scr) from running from USB removable drives, including SD cards.</p>
 <p>This ASR rule doesn't block the files from being copied from the USB drive to disk. It blocks the copied files from running from disk.</p>
@@ -1690,10 +1731,6 @@
 </li>
 <li><strong>Dependencies</strong>: Microsoft Defender Antivirus</li>
 </ul>
-<div class="NOTE">
-<p>Note</p>
-<p>Currently, Microsoft Defender Vulnerability Management doesn't recognize this rule. The <a href="attack-surface-reduction-rules-report" data-linktype="relative-path">Attack surface reduction (ASR) rules report</a> shows this rule as <strong>Not applicable</strong>.</p>
-</div>
 <h4 id="block-webshell-creation-for-servers">Block Webshell creation for Servers</h4>
 <p>This ASR rule blocks web shell script creation on Windows servers running Microsoft Exchange. A web shell script is a crafted script that allows an attacker to control the compromised server. A web shell script might include the following functionality:</p>
 <ul>
@@ -1721,7 +1758,6 @@
 <ul>
 <li>This rule isn't supported when deployed via Microsoft Intune to Windows Server 2012 R2 or Windows Server 2016 using the <a href="onboard-server#functionality-in-the-modern-unified-solution-for-windows-server-2016-and-windows-server-2012-r2" data-linktype="relative-path">modern unified solution</a>.</li>
 <li>If you manage ASR rules in Microsoft Defender for Endpoint, don't configure this ASR in Group Policy or other local settings (leave the value as <code>Not Configured</code>). Any other value (for example, <code>Enabled</code> or <code>Disabled</code>) can cause conflicts and prevent the rule from applying correctly.</li>
-<li>Currently, Microsoft Defender Vulnerability Management doesn't recognize this rule. The <a href="attack-surface-reduction-rules-report" data-linktype="relative-path">Attack surface reduction (ASR) rules report</a> shows this rule as <strong>Not applicable</strong>.</li>
 </ul>
 </div>
 <h4 id="block-win32-api-calls-from-office-macros">Block Win32 API calls from Office macros</h4>
@@ -1776,7 +1812,7 @@
 <li><a href="attack-surface-reduction-rules-deployment-implement" data-linktype="relative-path">Enable attack surface reduction (ASR) rules</a></li>
 <li><a href="attack-surface-reduction-rules-deployment-operationalize" data-linktype="relative-path">Manage and monitor your attack surface reduction (ASR) rules deployment</a></li>
 <li><a href="attack-surface-reduction-rules-report" data-linktype="relative-path">Attack surface reduction (ASR) rules report</a></li>
-<li><a href="defender-endpoint-antivirus-exclusions" data-linktype="relative-path">Exclusions for Microsoft Defender for Endpoint and Microsoft Defender Antivirus</a></li>
+<li><a href="defender-endpoint-exclusions-overview" data-linktype="relative-path">Exclusions for Microsoft Defender for Endpoint and Microsoft Defender Antivirus</a></li>
 <li><a href="troubleshoot-asr" data-linktype="relative-path">Troubleshoot ASR rules</a></li>
 </ul>
 </div>
@@ -1991,11 +2027,11 @@
 				<li class="visibility-hidden-visual-diff">
 			<span class="badge badge-sm text-wrap-pretty">
 				<span>Last updated on <local-time format="twoDigitNumeric"
-		datetime="2026-05-22T07:35:00.000Z"
+		datetime="2026-07-02T08:00:00.000Z"
 		data-article-date-source="calculated"
 		class="is-invisible"
 	>
-		2026-05-22
+		2026-07-02
 	</local-time></span>
 			</span>
 		</li>
@@ -2266,8 +2302,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -2277,11 +2313,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -2300,13 +2339,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -2325,13 +2367,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -2350,7 +2395,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2008_lifecycle.html
+++ b/tests/fixtures/ms/server2008_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -614,8 +661,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -625,11 +672,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -648,13 +698,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -673,13 +726,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -698,7 +754,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2008r2_lifecycle.html
+++ b/tests/fixtures/ms/server2008r2_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -607,8 +654,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -618,11 +665,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -641,13 +691,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -666,13 +719,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -691,7 +747,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2012_lifecycle.html
+++ b/tests/fixtures/ms/server2012_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -152,7 +196,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -352,7 +399,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -593,8 +640,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -604,11 +651,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -627,13 +677,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -652,13 +705,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -677,7 +733,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2012r2_lifecycle.html
+++ b/tests/fixtures/ms/server2012r2_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -587,8 +634,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -598,11 +645,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -621,13 +671,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -646,13 +699,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -671,7 +727,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2016_lifecycle.html
+++ b/tests/fixtures/ms/server2016_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -533,8 +580,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -544,11 +591,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -567,13 +617,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -592,13 +645,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -617,7 +673,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2019_lifecycle.html
+++ b/tests/fixtures/ms/server2019_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -537,8 +584,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -548,11 +595,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -571,13 +621,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -596,13 +649,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -621,7 +677,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2022_lifecycle.html
+++ b/tests/fixtures/ms/server2022_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -144,7 +188,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -344,7 +391,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -540,8 +587,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -551,11 +598,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -574,13 +624,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -599,13 +652,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -624,7 +680,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/server2025_lifecycle.html
+++ b/tests/fixtures/ms/server2025_lifecycle.html
@@ -91,13 +91,52 @@
 		<meta name="markdown_url" content="https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2025?accept=text/markdown" />
 	 
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "lifecycle-view";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -117,6 +156,11 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Lifecycle",
+    "layoutStateStorageKey": "docs-layout-persistence",
+    "layoutStateExcludesKey": "lifecycle-view",
+    "layoutStateExcludes": [
+      "layout-flyout-active"
+    ],
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -148,7 +192,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -348,7 +395,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -522,8 +569,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -533,11 +580,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -556,13 +606,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -581,13 +634,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -606,7 +662,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/win11_release_info.html
+++ b/tests/fixtures/ms/win11_release_info.html
@@ -58,19 +58,19 @@
 	
 		<meta name="author" content="WindowsCommunications" />
 	
-		<meta name="ms.date" content="2026-05-14T00:00:00Z" />
+		<meta name="ms.date" content="2026-07-14T00:00:00Z" />
 	
 		<meta name="document_id" content="3f5cd300-2fe0-dcb9-4748-518f957c0cbb" />
 	
 		<meta name="document_version_independent_id" content="3f5cd300-2fe0-dcb9-4748-518f957c0cbb" />
 	
-		<meta name="updated_at" content="2026-05-15T01:27:00Z" />
+		<meta name="updated_at" content="2026-07-19T03:21:00Z" />
 	
 		<meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/live/windows/release-information/windows11-release-information.md" />
 	
-		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/d222327d252dd4a787267913a4e2fd8c3002b42c/windows/release-information/windows11-release-information.md" />
+		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/72c2b8bc2bf2c54ae34b6c38dd3c7890b5e15e7b/windows/release-information/windows11-release-information.md" />
 	
-		<meta name="git_commit_id" content="d222327d252dd4a787267913a4e2fd8c3002b42c" />
+		<meta name="git_commit_id" content="72c2b8bc2bf2c54ae34b6c38dd3c7890b5e15e7b" />
 	
 		<meta name="site_name" content="Docs" />
 	
@@ -86,7 +86,7 @@
 	
 		<meta name="feedback_help_link_url" content="" />
 	
-		<meta name="word_count" content="3325" />
+		<meta name="word_count" content="3477" />
 	
 		<meta name="asset_id" content="windows11-release-information" />
 	
@@ -96,7 +96,7 @@
 	
 		<meta name="source_path" content="windows/release-information/windows11-release-information.md" />
 	
-		<meta name="previous_tlsh_hash" content="A9CADDC216D485E21F713C26EF589B7A9240A2DDC55DA806A2A3F61EB0E4F7A4D18DF2B1FEF2F0A042337A47954750562DC04138B2C3A2769004B265AF4FE6A0D737E97DBC" />
+		<meta name="previous_tlsh_hash" content="31BC9DC204D085E25F713C26EF589B7A9244A2DDC55DA806A2A3B61EB0E4F7A4D28DF3B1FEF2F0A042337A47954750562DC04138B2C3B2769004B255AF4FE6A0D737E97DAC" />
 	
 		<meta name="2PlusCloud" content="Azure" />
 	
@@ -119,13 +119,52 @@
 		<meta name="2PlusCloud" content="M365" data-source="generated" />
 	
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -145,6 +184,7 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Conceptual",
+    "layoutStateStorageKey": "docs-layout-persistence",
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -176,7 +216,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -287,7 +330,7 @@
 					
 		<div
 			id="left-container"
-			class="left-container display-none padding-none display-block-tablet width-full"
+			class="left-container display-none padding-none display-block-tablet width-full display-none-until-layout-restored"
 			data-toc-container="true"
 		>
 			<div
@@ -310,11 +353,17 @@
 							class="button button-clear inner-focus"
 							data-collapsible-toc-toggle
 							aria-expanded="true"
+							hidden
 							aria-controls="ms--toc-content"
 							aria-label="Table of contents"
 						>
 							<span class="icon icon-mirrored-rtl font-size-md" aria-hidden="true">
-								<span class="docon docon-panel-left-contract"></span>
+								<span
+									class="docon docon-panel-left-contract display-none-layout-menu-collapsed"
+								></span>
+								<span
+									class="docon docon-panel-left-expand display-none display-inline-layout-menu-collapsed"
+								></span>
 							</span>
 						</button>
 						<div
@@ -484,7 +533,7 @@
 		<button
 			data-page-action-item="overflow-mobile"
 			type="button"
-			class="button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
+			class="display-block-layout-menu-collapsed button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
 			data-bi-name="contents-expand"
 			data-contents-button
 			data-popover-close
@@ -540,7 +589,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -711,9 +760,9 @@
 <td nowrap="">2026-02-10</td>
 <td nowrap="">2028-03-14</td>
 <td nowrap="">2029-03-13</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5089548" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">28000.2113</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5101649" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">28000.2525</td>
      </tr>
 <tr class="highlight">
 <td>25H2</td>
@@ -721,19 +770,19 @@
 <td nowrap="">2025-09-30</td>
 <td nowrap="">2027-10-12</td>
 <td nowrap="">2028-10-10</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5089549" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">26200.8457</td>
-     </tr>
+<td nowrap=""><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">2026-07 OOB</a></td>
+<td nowrap="">2026-07-18</td>
+<td nowrap="">26200.8894</td>
+</tr>
 <tr class="highlight">
 <td>24H2</td>
 <td align="left">General Availability Channel</td>
 <td nowrap="">2024-10-01</td>
 <td nowrap="">2026-10-13</td>
 <td nowrap="">2027-10-12</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5089549" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">26100.8457</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">2026-07 OOB</a></td>
+<td nowrap="">2026-07-18</td>
+<td nowrap="">26100.8894</td>
      </tr>
 <tr class="highlight">
 <td>23H2</td>
@@ -741,9 +790,9 @@
 <td nowrap="">2023-10-31</td>
 <td nowrap="">End of updates</td>
 <td nowrap="">2026-11-10</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5087420" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">22631.7079</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5099414" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">22631.7376</td>
      </tr>
 </tbody></table>
 <h4 id="enterprise-and-iot-enterprise-ltsc-editions">Enterprise and IoT Enterprise LTSC editions</h4>
@@ -753,9 +802,9 @@
 <td nowrap="">2024-10-01</td>
 <td nowrap="">2029-10-09</td>
 <td nowrap="">2034-10-10</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5089549" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">26100.8457</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">2026-07 OOB</a></td>
+<td nowrap="">2026-07-18</td>
+<td nowrap="">26100.8894</td>
 </tr>
 </tbody></table>
 <div class="NOTE">
@@ -773,6 +822,41 @@
 <table class="cells-centered" id="historyTable_0">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
 <tr>
+<td>General Availability Channel</td>
+<td>2026-07 OOB</td>
+<td>2026-07-18</td>
+<td>26200.8894</td>
+<td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>26200.8875</td>
+<td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-06 D</td>
+<td>2026-06-23</td>
+<td>26200.8737</td>
+<td><a href="https://support.microsoft.com/help/5095093" target="_blank" data-linktype="external">KB5095093</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>26200.8655</td>
+<td><a href="https://support.microsoft.com/help/5094126" target="_blank" data-linktype="external">KB5094126</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-05 D</td>
+<td>2026-05-26</td>
+<td>26200.8524</td>
+<td><a href="https://support.microsoft.com/help/5089573" target="_blank" data-linktype="external">KB5089573</a></td>
+</tr>
+     <tr>
 <td>General Availability Channel</td>
 <td>2026-05 B</td>
 <td>2026-05-12</td>
@@ -920,6 +1004,34 @@
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
 <tr>
 <td>General Availability Channel</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>28000.2525</td>
+<td><a href="https://support.microsoft.com/help/5101649" target="_blank" data-linktype="external">KB5101649</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-06 D</td>
+<td>2026-06-23</td>
+<td>28000.2340</td>
+<td><a href="https://support.microsoft.com/help/5095091" target="_blank" data-linktype="external">KB5095091</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>28000.2269</td>
+<td><a href="https://support.microsoft.com/help/5095051" target="_blank" data-linktype="external">KB5095051</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-05 D</td>
+<td>2026-05-26</td>
+<td>28000.2179</td>
+<td><a href="https://support.microsoft.com/help/5089570" target="_blank" data-linktype="external">KB5089570</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
 <td>2026-05 B</td>
 <td>2026-05-12</td>
 <td>28000.2113</td>
@@ -982,6 +1094,41 @@
 <table class="cells-centered" id="historyTable_2">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
 <tr>
+<td>LTSC <span> • </span> General Availability Channel</td>
+<td>2026-07 OOB</td>
+<td>2026-07-18</td>
+<td>26100.8894</td>
+<td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td>
+</tr>
+     <tr>
+<td>LTSC <span> • </span> General Availability Channel</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>26100.8875</td>
+<td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td>
+</tr>
+     <tr>
+<td>LTSC <span> • </span> General Availability Channel</td>
+<td>2026-06 D</td>
+<td>2026-06-23</td>
+<td>26100.8737</td>
+<td><a href="https://support.microsoft.com/help/5095093" target="_blank" data-linktype="external">KB5095093</a></td>
+</tr>
+     <tr>
+<td>LTSC <span> • </span> General Availability Channel</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>26100.8655</td>
+<td><a href="https://support.microsoft.com/help/5094126" target="_blank" data-linktype="external">KB5094126</a></td>
+</tr>
+     <tr>
+<td>LTSC <span> • </span> General Availability Channel</td>
+<td>2026-05 D</td>
+<td>2026-05-26</td>
+<td>26100.8524</td>
+<td><a href="https://support.microsoft.com/help/5089573" target="_blank" data-linktype="external">KB5089573</a></td>
+</tr>
+     <tr>
 <td>LTSC <span> • </span> General Availability Channel</td>
 <td>2026-05 B</td>
 <td>2026-05-12</td>
@@ -1333,6 +1480,20 @@
 <table class="cells-centered" id="historyTable_3">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
 <tr>
+<td>General Availability Channel</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>22631.7376</td>
+<td><a href="https://support.microsoft.com/help/5099414" target="_blank" data-linktype="external">KB5099414</a></td>
+</tr>
+     <tr>
+<td>General Availability Channel</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>22631.7219</td>
+<td><a href="https://support.microsoft.com/help/5093998" target="_blank" data-linktype="external">KB5093998</a></td>
+</tr>
+     <tr>
 <td>General Availability Channel</td>
 <td>2026-05 B</td>
 <td>2026-05-12</td>
@@ -2790,18 +2951,18 @@
      <tr>
              <td>June</td>
              <td>2026.06 B</td>
-             <td>Hotpatch</td>
-             <td></td>
-             <td></td>
-<td></td>
+             <td>Baseline (Restart)</td>
+             <td>2026-06-09</td>
+             <td>26200.8655</td>
+<td><a href="https://support.microsoft.com/help/5094126" target="_blank" data-linktype="external">KB5094126</a></td>
      </tr>
      <tr>
              <td>July</td>
              <td>2026.07 B</td>
              <td>Baseline (Restart)</td>
-             <td></td>
-             <td></td>
-<td></td>
+             <td>2026-07-14</td>
+             <td>26200.8875</td>
+<td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td>
      </tr>
      <tr>
              <td>August</td>
@@ -2925,18 +3086,18 @@
      <tr>
              <td>June</td>
              <td>2026.06 B</td>
-             <td>Hotpatch</td>
-             <td></td>
-             <td></td>
-<td></td>
+             <td>Baseline (Restart)</td>
+            <td>2026-06-09</td>
+             <td>26100.8655</td>
+<td><a href="https://support.microsoft.com/help/5094126" target="_blank" data-linktype="external">KB5094126</a></td>
      </tr>
      <tr>
              <td>July</td>
              <td>2026.07 B</td>
              <td>Baseline (Restart)</td>
-             <td></td>
-             <td></td>
-<td></td>
+             <td>2026-07-14</td>
+             <td>26100.8875</td>
+<td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td>
      </tr>
      <tr>
              <td>August</td>
@@ -3175,11 +3336,11 @@
 				<li class="visibility-hidden-visual-diff">
 			<span class="badge badge-sm text-wrap-pretty">
 				<span>Last updated on <local-time format="twoDigitNumeric"
-		datetime="2026-05-14T08:00:00.000Z"
+		datetime="2026-07-14T08:00:00.000Z"
 		data-article-date-source="calculated"
 		class="is-invisible"
 	>
-		2026-05-14
+		2026-07-14
 	</local-time></span>
 			</span>
 		</li>
@@ -3303,8 +3464,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -3314,11 +3475,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -3337,13 +3501,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -3362,13 +3529,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -3387,7 +3557,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/fixtures/ms/win_release_info.html
+++ b/tests/fixtures/ms/win_release_info.html
@@ -58,19 +58,19 @@
 	
 		<meta name="author" content="WindowsCommunications" />
 	
-		<meta name="ms.date" content="2026-05-12T00:00:00Z" />
+		<meta name="ms.date" content="2026-07-14T00:00:00Z" />
 	
 		<meta name="document_id" content="89c3cd2c-cd3e-bf48-3d62-d3d681e29b15" />
 	
 		<meta name="document_version_independent_id" content="89c3cd2c-cd3e-bf48-3d62-d3d681e29b15" />
 	
-		<meta name="updated_at" content="2026-05-12T23:46:00Z" />
+		<meta name="updated_at" content="2026-07-14T18:55:00Z" />
 	
 		<meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/live/windows/release-information/release-information.md" />
 	
-		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/4e7ac16cc22edd40c15b14abd8bcba049b2639a5/windows/release-information/release-information.md" />
+		<meta name="gitcommit" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/549900fbd5f514a3c9b9f07e19f14ad8e9f145de/windows/release-information/release-information.md" />
 	
-		<meta name="git_commit_id" content="4e7ac16cc22edd40c15b14abd8bcba049b2639a5" />
+		<meta name="git_commit_id" content="549900fbd5f514a3c9b9f07e19f14ad8e9f145de" />
 	
 		<meta name="site_name" content="Docs" />
 	
@@ -86,7 +86,7 @@
 	
 		<meta name="feedback_help_link_url" content="" />
 	
-		<meta name="word_count" content="10682" />
+		<meta name="word_count" content="10742" />
 	
 		<meta name="asset_id" content="release-information" />
 	
@@ -96,7 +96,7 @@
 	
 		<meta name="source_path" content="windows/release-information/release-information.md" />
 	
-		<meta name="previous_tlsh_hash" content="488D95837B9646690F7CAEAAE7B5CAE9C0D0DBC0C4DECC40C262FA1335F07768539F19B4FDBBB4561C7B3B8E78C741D9D64A5034B6C2E31AE4413B0AB541C7909AABE40769" />
+		<meta name="previous_tlsh_hash" content="6CF0CC837B8646690F7CAEAAE7B5CAE9C0D0DBC0C4DECC40C662FA1335F07768539F19B4FDBBB4561C7B3B8E78C741D9D64A5034B6C2E31AE4413B0AB541C7909AABE40769" />
 	
 		<meta name="github_feedback_content_git_url" content="https://github.com/MicrosoftDocs/windows-release-pr/blob/live/windows/release-information/release-information.md" />
 	
@@ -107,13 +107,52 @@
 		<meta name="spProducts" content="https://authoring-docs-microsoft.poolparty.biz/devrel/3904bce4-d817-48cf-85fd-b6146fca83b7" data-source="generated" />
 	
 
+			<!-- Apply persisted/system theme before first paint to prevent wrong-theme flash when scripts are deferred. -->
+			<script id="theme-preference">
+				(function () {
+			try {
+				var stored = localStorage.getItem('theme');
+				var theme = /^(light|dark|high-contrast)$/.test(stored)
+					? stored
+					: matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				document.documentElement.classList.add('theme-' + theme);
+			} catch (e) {}
+		})();;
+			</script>
+
+			<script id="atlas-layout-preferences">
+				(function () {
+			try {
+				var state = JSON.parse(localStorage.getItem('atlas-layout-preferences') || '{}');
+				var view = state["docs-layout-persistence"] || {};
+				var excludesKey = "";
+				var blocked = {};
+				if (excludesKey) {
+					var exclusions = JSON.parse(localStorage.getItem('atlas-layout-exclusions') || '{}');
+					if (Object.prototype.hasOwnProperty.call(exclusions, excludesKey)) {
+						var scoped = exclusions[excludesKey];
+						if (scoped) {
+							if (typeof scoped === 'object') blocked = scoped;
+						}
+					}
+				}
+				var html = document.documentElement;
+				for (var c in view) {
+					if (Object.prototype.hasOwnProperty.call(blocked, c)) continue;
+					if (view[c]) html.classList.add(c);
+					else html.classList.remove(c);
+				}
+			} catch (e) {}
+		})();;
+			</script>
+
 			<!-- assets and js globals -->
 			
-			<link rel="stylesheet" href="/static/assets/0.4.03427.7856-752ce836/styles/site.css" />
+			<link rel="stylesheet" href="/static/assets/0.4.03487.8036-44229b5b/styles/site.css" />
 			
 			<script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
-			<script src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
-			<script src="/_themes/docs.theme/master/en-us/_themes/global/deprecation.js"></script>
+			<script async src="https://js.monitor.azure.com/scripts/c/ms.jsll-4.min.js"></script>
+			
 
 			<!-- msdocs global object -->
 			<script id="msdocs-script">
@@ -133,6 +172,7 @@
     "userLocale": "en-us",
     "userDir": "ltr",
     "pageTemplate": "Conceptual",
+    "layoutStateStorageKey": "docs-layout-persistence",
     "brand": "",
     "context": {},
     "standardFeedback": false,
@@ -168,7 +208,10 @@
 	</script>
 
 			<!-- base scripts, msdocs global should be before this -->
-			<script src="/static/assets/0.4.03427.7856-752ce836/scripts/en-us/index-docs.js"></script>
+			<script
+				src="/static/assets/0.4.03487.8036-44229b5b/scripts/en-us/index-docs.js"
+				async
+			></script>
 			
 
 			<!-- json-ld -->
@@ -279,7 +322,7 @@
 					
 		<div
 			id="left-container"
-			class="left-container display-none padding-none display-block-tablet width-full"
+			class="left-container display-none padding-none display-block-tablet width-full display-none-until-layout-restored"
 			data-toc-container="true"
 		>
 			<div
@@ -302,11 +345,17 @@
 							class="button button-clear inner-focus"
 							data-collapsible-toc-toggle
 							aria-expanded="true"
+							hidden
 							aria-controls="ms--toc-content"
 							aria-label="Table of contents"
 						>
 							<span class="icon icon-mirrored-rtl font-size-md" aria-hidden="true">
-								<span class="docon docon-panel-left-contract"></span>
+								<span
+									class="docon docon-panel-left-contract display-none-layout-menu-collapsed"
+								></span>
+								<span
+									class="docon docon-panel-left-expand display-none display-inline-layout-menu-collapsed"
+								></span>
 							</span>
 						</button>
 						<div
@@ -476,7 +525,7 @@
 		<button
 			data-page-action-item="overflow-mobile"
 			type="button"
-			class="button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
+			class="display-block-layout-menu-collapsed button-block button-sm inner-focus button button-clear display-none-tablet justify-content-flex-start text-align-left"
 			data-bi-name="contents-expand"
 			data-contents-button
 			data-popover-close
@@ -532,7 +581,7 @@
 			<span class="icon" aria-hidden="true">
 				<span class="docon docon-circle-addition"></span>
 			</span>
-			<span class="plan-status">Add to plan</span>
+			<span class="plan-status">Add to Plans</span>
 		</button>
 	 
 					
@@ -720,9 +769,9 @@
 <td nowrap="">2022-10-18</td>
 <td nowrap="">End of updates</td>
 <td nowrap="">End of updates</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5087544" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">19045.7291</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5099539" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">19045.7548</td>
      </tr>
 </tbody></table>
 <h4 id="enterprise-and-iot-enterprise-ltsbltsc-editions">Enterprise and IoT Enterprise LTSB/LTSC editions</h4>
@@ -732,27 +781,27 @@
 <td nowrap="">2021-11-16</td>
 <td nowrap="">2027-01-12</td>
 <td nowrap="">2032-01-13 (IoT Enterprise only)</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5087544" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">19044.7291</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5099539" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">19044.7548</td>
 </tr>
 <tr><td>2019 (1809)</td>
              <td align="left">Long-Term Servicing Channel (LTSC)</td>
 <td nowrap="">2018-11-13</td>
 <td nowrap="">End of updates</td>
 <td nowrap="">2029-01-09</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5087538" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">17763.8755</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5099538" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">17763.9020</td>
 </tr>
 <tr><td>2016 (1607)</td>
              <td align="left">Long-Term Servicing Branch (LTSB)</td>
 <td nowrap="">2016-08-02</td>
 <td nowrap="">End of updates</td>
 <td nowrap="">2026-10-13</td>
-<td nowrap=""><a href="https://support.microsoft.com/help/5087537" target="_blank" data-linktype="external">2026-05 B</a></td>
-<td nowrap="">2026-05-12</td>
-<td nowrap="">14393.9140</td>
+<td nowrap=""><a href="https://support.microsoft.com/help/5099535" target="_blank" data-linktype="external">2026-07 B</a></td>
+<td nowrap="">2026-07-14</td>
+<td nowrap="">14393.9339</td>
 </tr>
 </tbody></table>
 <div class="NOTE">
@@ -766,6 +815,20 @@
 <p>To update devices running Windows 10, version 20H2 or 21H2 to version 22H2, you can speed up the update process using an <a href="https://aka.ms/ekb-22H2" target="_blank" data-linktype="external">enablement package</a>.</p>
 <table class="cells-centered" id="historyTable_0">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr>
+<td>General Availability Channel</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>19045.7548</td>
+<td><a href="https://support.microsoft.com/help/5099539" target="_blank" data-linktype="external">KB5099539</a></td>
+</tr>
+<tr>
+<td>General Availability Channel</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>19045.7417</td>
+<td><a href="https://support.microsoft.com/help/5094127" target="_blank" data-linktype="external">KB5094127</a></td>
+</tr>
 <tr>
 <td>General Availability Channel</td>
 <td>2026-05 B</td>
@@ -1361,6 +1424,20 @@
 <p>To update devices running Windows 10, version 2004, 20H2, or 21H1 to Windows 10, version 21H2, you can speed up the update process using an <a href="https://aka.ms/ekb-21H2" target="_blank" data-linktype="external">enablement package</a>.</p>
 <table class="cells-centered" id="historyTable_1">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr>
+<td>LTSC</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>19044.7548</td>
+<td><a href="https://support.microsoft.com/help/5099539" target="_blank" data-linktype="external">KB5099539</a></td>
+</tr>
+<tr>
+<td>LTSC</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>19044.7417</td>
+<td><a href="https://support.microsoft.com/help/5094127" target="_blank" data-linktype="external">KB5094127</a></td>
+</tr>
 <tr>
 <td>LTSC</td>
 <td>2026-05 B</td>
@@ -3776,6 +3853,20 @@
 </summary>
 <table class="cells-centered" id="historyTable_7">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr>
+<td>LTSC</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>17763.9020</td>
+<td><a href="https://support.microsoft.com/help/5099538" target="_blank" data-linktype="external">KB5099538</a></td>
+</tr>
+<tr>
+<td>LTSC</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>17763.8880</td>
+<td><a href="https://support.microsoft.com/help/5094123" target="_blank" data-linktype="external">KB5094123</a></td>
+</tr>
 <tr>
 <td>LTSC</td>
 <td>2026-05 B</td>
@@ -6422,6 +6513,20 @@
 </summary>
 <table class="cells-centered" id="historyTable_11">
 <tbody><tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr>
+<td>CBB <span> • </span> CB <span> • </span> LTSB</td>
+<td>2026-07 B</td>
+<td>2026-07-14</td>
+<td>14393.9339</td>
+<td><a href="https://support.microsoft.com/help/5099535" target="_blank" data-linktype="external">KB5099535</a></td>
+</tr>
+<tr>
+<td>CBB <span> • </span> CB <span> • </span> LTSB</td>
+<td>2026-06 B</td>
+<td>2026-06-09</td>
+<td>14393.9234</td>
+<td><a href="https://support.microsoft.com/help/5094122" target="_blank" data-linktype="external">KB5094122</a></td>
+</tr>
 <tr>
 <td>CBB <span> • </span> CB <span> • </span> LTSB</td>
 <td>2026-05 B</td>
@@ -9097,11 +9202,11 @@
 				<li class="visibility-hidden-visual-diff">
 			<span class="badge badge-sm text-wrap-pretty">
 				<span>Last updated on <local-time format="twoDigitNumeric"
-		datetime="2026-05-12T08:00:00.000Z"
+		datetime="2026-07-14T08:00:00.000Z"
 		data-article-date-source="calculated"
 		class="is-invisible"
 	>
-		2026-05-12
+		2026-07-14
 	</local-time></span>
 			</span>
 		</li>
@@ -9225,8 +9330,8 @@
 				data-test-id="theme-selector-button"
 				class="dropdown-trigger button button-clear button-sm inner-focus theme-dropdown-trigger"
 				aria-controls="{{ themeMenuId }}"
+				aria-haspopup="true"
 				aria-expanded="false"
-				title="Theme"
 				data-bi-name="theme"
 			>
 				<span class="icon" aria-hidden="true"><span class="docon docon-sun"></span></span>
@@ -9236,11 +9341,14 @@
 				</span>
 			</button>
 			<div class="dropdown-menu" id="{{ themeMenuId }}" role="menu">
-				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu">
-					<li class="theme display-block">
+				<ul class="theme-selector padding-xxs" data-test-id="theme-dropdown-menu" role="none">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="light"
+							tabindex="-1"
 						>
 							<span class="theme-light margin-right-xxs">
 								<span
@@ -9259,13 +9367,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Light </span>
+							<span> Light </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="dark"
+							tabindex="-1"
 						>
 							<span class="theme-dark margin-right-xxs">
 								<span
@@ -9284,13 +9395,16 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> Dark </span>
+							<span> Dark </span>
 						</button>
 					</li>
-					<li class="theme display-block">
+					<li class="theme display-block" role="none">
 						<button
 							class="button button-clear button-sm theme-control button-block justify-content-flex-start text-align-left"
+							role="menuitemradio"
+							aria-checked="false"
 							data-theme-to="high-contrast"
+							tabindex="-1"
 						>
 							<span class="theme-high-contrast margin-right-xxs">
 								<span
@@ -9309,7 +9423,7 @@
 									</svg>
 								</span>
 							</span>
-							<span role="menuitem"> High contrast </span>
+							<span> High contrast </span>
 						</button>
 					</li>
 				</ul>

--- a/tests/test_ms_scrapers.py
+++ b/tests/test_ms_scrapers.py
@@ -18,7 +18,8 @@ from src.scrapers.ms.m365_buildnumbers import _SOURCE_URL as M365_URL
 from src.scrapers.ms.m365_buildnumbers import M365BuildNumbersScraper
 from src.scrapers.ms.win_lifecycle_client import _SOURCES as LC_SOURCES
 from src.scrapers.ms.win_lifecycle_client import WinLifecycleClientScraper
-from src.scrapers.ms.win_lifecycle_ltsc import _SOURCE_URL as LTSC_URL
+from src.scrapers.ms.win_lifecycle_ltsc import _WIN10_URL as LTSC_WIN10_URL
+from src.scrapers.ms.win_lifecycle_ltsc import _WIN11_URL as LTSC_WIN11_URL
 from src.scrapers.ms.win_lifecycle_ltsc import WinLifecycleLtscScraper
 from src.scrapers.ms.win_lifecycle_server import _SOURCES as LS_SOURCES
 from src.scrapers.ms.win_lifecycle_server import WinLifecycleServerScraper
@@ -57,7 +58,10 @@ def lifecycle_client_pages():
 
 @pytest.fixture(scope="module")
 def lifecycle_ltsc_pages():
-    return {LTSC_URL: (F / "win_release_info.html").read_text()}
+    return {
+        LTSC_WIN10_URL: (F / "win_release_info.html").read_text(),
+        LTSC_WIN11_URL: (F / "win11_release_info.html").read_text(),
+    }
 
 
 @pytest.fixture(scope="module")
@@ -176,6 +180,16 @@ class TestWinLifecycleLtscScraper:
         versions = [r["version"] for r in records]
         assert len(versions) == len(set(versions))
 
+    def test_includes_windows11_ltsc_2024(self, lifecycle_ltsc_pages):
+        # Regression: Win11 LTSC 2024 lives on the Windows 11 release-health
+        # page and was missing while only the Windows 10 page was scraped.
+        records = WinLifecycleLtscScraper().parse(lifecycle_ltsc_pages)
+        assert any(r["build"] == "26100" for r in records)
+
+    def test_no_footnote_markers_in_version(self, lifecycle_ltsc_pages):
+        for r in WinLifecycleLtscScraper().parse(lifecycle_ltsc_pages):
+            assert "24H21" not in r["version"]  # "24H2" + <sup>1</sup> footnote
+
 
 # ---------------------------------------------------------------------------
 # WinLifecycleServerScraper
@@ -202,6 +216,15 @@ class TestWinLifecycleServerScraper:
         versions = {r["version"] for r in WinLifecycleServerScraper().parse(lifecycle_server_pages)}
         for year in ("2008", "2012", "2016", "2019", "2022", "2025"):
             assert any(year in v for v in versions), f"Missing Server {year}"
+
+    def test_includes_sp_and_esu_tiers(self, lifecycle_server_pages):
+        # Regression: SP / ESU tier rows come from the per-product releases
+        # table and were dropped when only the listing table was parsed.
+        records = WinLifecycleServerScraper().parse(lifecycle_server_pages)
+        tiers = {r["tier"] for r in records}
+        assert any(t.startswith("Service Pack") for t in tiers)
+        assert any("Extended Security Update" in t for t in tiers)
+        assert len(records) >= 25
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +304,14 @@ class TestAsrGuidsScraper:
     def test_guids_are_valid_uuids(self):
         for r in AsrGuidsScraper().parse({ASR_URL: (F / "asr_guids.html").read_text()}):
             assert UUID_RE.fullmatch(r["asr_guid"]), f"Invalid UUID: {r['asr_guid']}"
+
+    def test_includes_ransomware_rule(self):
+        # Regression: this rule's section has a descriptive <ul> before the
+        # GUID <ul>, so first-list-only parsing silently skipped it.
+        records = AsrGuidsScraper().parse({ASR_URL: (F / "asr_guids.html").read_text()})
+        guids = {r["asr_guid"] for r in records}
+        assert "c1db55ab-c21a-4637-bb3f-a12568109d35" in guids
+        assert len(records) >= 19
 
     def test_guids_are_lowercase(self):
         for r in AsrGuidsScraper().parse({ASR_URL: (F / "asr_guids.html").read_text()}):
@@ -391,7 +422,7 @@ class TestValueErrorGuards:
 
     def test_win_lifecycle_ltsc_raises_on_missing_table(self):
         with pytest.raises(StructureChangedError, match="page structure may have changed"):
-            WinLifecycleLtscScraper().parse({LTSC_URL: _EMPTY})
+            WinLifecycleLtscScraper().parse({LTSC_WIN10_URL: _EMPTY, LTSC_WIN11_URL: _EMPTY})
 
     def test_win_lifecycle_server_raises_on_empty(self):
         with pytest.raises(StructureChangedError, match="page structure may have changed"):


### PR DESCRIPTION
## Summary
Fixes the three data-completeness gaps and the silent-corruption risk found in the project review:

- **LTSC lifecycle (3 → 4 records):** now also scrapes the Windows 11 release-health page, adding the missing **Windows 11 Enterprise LTSC 2024** entry (build 26100, mainstream to 2029-10-09, extended to 2034-10-10). Footnote `<sup>` markers are stripped from cells (the Win11 version cell renders as `24H2<sup>1</sup>`).
- **Server lifecycle (8 → 28 records):** parses the per-product "Version | Start Date | End Date" releases table in addition to the listing table, restoring the Service Pack / ESU-year / Original Release tier rows that the README documents but the Python rewrite dropped. For tier rows the single end date fills both end-date fields, since all support for the tier stops on that date.
- **ASR GUIDs (18 → 19 records):** scans every `<ul>` between rule headings instead of only the first, recovering **"Use advanced protection against ransomware"** (`c1db55ab-c21a-4637-bb3f-a12568109d35`), whose GUID list follows a descriptive bullet list.
- **M365 buildnumbers (no output change, 912 records):** the history table is now located by header text and channel column indices are derived from the header row instead of hardcoded positions 2–5 — a column insertion or reorder now raises `StructureChangedError` instead of silently attributing builds to the wrong channel.

Refreshed the affected HTML fixtures from live pages and added regression tests for each recovered record class.

## Test plan
- [x] 5 new regression tests (LTSC 2024 present, no footnote artifacts, SP/ESU tiers present, ransomware GUID present, tightened count floors)
- [x] Full suite: 216 passed; ruff clean
- [x] Live regeneration of all four datasets; M365 output verified byte-identical to published data

🤖 Generated with [Claude Code](https://claude.com/claude-code)